### PR TITLE
Bug on NetworkStoreListener.onCreation when creating an HVDC converter station

### DIFF
--- a/src/main/java/org/gridsuite/modification/server/dto/EquipmentType.java
+++ b/src/main/java/org/gridsuite/modification/server/dto/EquipmentType.java
@@ -19,7 +19,7 @@ public enum EquipmentType {
     DISCONNECTOR,
     LOAD_BREAK_SWITCH,
 
-    // Same as com.powsybl.iidm.network.ConnectableType
+    // Same as com.powsybl.iidm.network.IdentifiableType
     BUSBAR_SECTION,
     LINE,
     TWO_WINDINGS_TRANSFORMER,
@@ -30,8 +30,7 @@ public enum EquipmentType {
     SHUNT_COMPENSATOR,
     DANGLING_LINE,
     STATIC_VAR_COMPENSATOR,
-    LCC_CONVERTER_STATION,
-    VSC_CONVERTER_STATION,
+    HVDC_CONVERTER_STATION,
 
     // Other
     CONFIGURED_BUS,

--- a/src/main/java/org/gridsuite/modification/server/service/NetworkModificationService.java
+++ b/src/main/java/org/gridsuite/modification/server/service/NetworkModificationService.java
@@ -445,11 +445,8 @@ public class NetworkModificationService {
                     case DANGLING_LINE:
                         identifiable = network.getDanglingLine(equipmentId);
                         break;
-                    case LCC_CONVERTER_STATION:
-                        identifiable = network.getLccConverterStation(equipmentId);
-                        break;
-                    case VSC_CONVERTER_STATION:
-                        identifiable = network.getVscConverterStation(equipmentId);
+                    case HVDC_CONVERTER_STATION:
+                        identifiable = network.getHvdcConverterStation(equipmentId);
                         break;
                     default:
                         break;

--- a/src/test/java/org/gridsuite/modification/server/ModificationControllerTest.java
+++ b/src/test/java/org/gridsuite/modification/server/ModificationControllerTest.java
@@ -1014,24 +1014,24 @@ public class ModificationControllerTest {
         testNetworkModificationsCount(TEST_GROUP_ID, 10);
 
         // delete vsc converter station
-        webTestClient.delete().uri(uriString, TEST_NETWORK_ID_2, "VSC_CONVERTER_STATION", "v2vsc")
+        webTestClient.delete().uri(uriString, TEST_NETWORK_ID_2, "HVDC_CONVERTER_STATION", "v2vsc")
             .exchange()
             .expectStatus().isOk()
             .expectHeader().contentType(MediaType.APPLICATION_JSON)
             .expectBodyList(EquipmentDeletionInfos.class)
             .value(modifications -> modifications.get(0),
-                MatcherEquipmentDeletionInfos.createMatcherEquipmentDeletionInfos(ModificationType.EQUIPMENT_DELETION, "v2vsc", "VSC_CONVERTER_STATION", Set.of("s1")));
+                MatcherEquipmentDeletionInfos.createMatcherEquipmentDeletionInfos(ModificationType.EQUIPMENT_DELETION, "v2vsc", "HVDC_CONVERTER_STATION", Set.of("s1")));
 
         testNetworkModificationsCount(TEST_GROUP_ID, 11);
 
         // delete lcc converter station
-        webTestClient.delete().uri(uriString, TEST_NETWORK_ID_2, "LCC_CONVERTER_STATION", "v1lcc")
+        webTestClient.delete().uri(uriString, TEST_NETWORK_ID_2, "HVDC_CONVERTER_STATION", "v1lcc")
             .exchange()
             .expectStatus().isOk()
             .expectHeader().contentType(MediaType.APPLICATION_JSON)
             .expectBodyList(EquipmentDeletionInfos.class)
             .value(modifications -> modifications.get(0),
-                MatcherEquipmentDeletionInfos.createMatcherEquipmentDeletionInfos(ModificationType.EQUIPMENT_DELETION, "v1lcc", "LCC_CONVERTER_STATION", Set.of("s1")));
+                MatcherEquipmentDeletionInfos.createMatcherEquipmentDeletionInfos(ModificationType.EQUIPMENT_DELETION, "v1lcc", "HVDC_CONVERTER_STATION", Set.of("s1")));
 
         testNetworkModificationsCount(TEST_GROUP_ID, 12);
     }


### PR DESCRIPTION
When creating a VSC converter station, following exception is thrown in method NetworkStoreListener.onCreation:
```
org.gridsuite.modification.server.NetworkModificationException: UNKNOWN_EQUIPMENT_TYPE : The equipment type : VscConverterStationImpl is unknown
```