### PR TITLE
Fix incorrect formatting for some javadoc

### DIFF
--- a/src/test/java/org/gridsuite/modification/server/utils/NetworkCreation.java
+++ b/src/test/java/org/gridsuite/modification/server/utils/NetworkCreation.java
@@ -270,16 +270,19 @@ public final class NetworkCreation {
     }
 
     /**
-     *     VL1            VL2            VL3
+     * Create a network as following:
+     * <pre>
+     *     VL1            VL2             VL3
      *
      *     ld1            g2              ld3
      *      |              |               |
      *     br1            br2             br3
-     *      |             |                |
-     *     d1             d2               d3
+     *      |              |               |
+     *     d1             d2              d3
      *      |              |               |
      *     bbs1 ----------bbs2------------bbs3
-     *            l1             l2
+     *              l1             l2
+     * </pre>
      */
     public static Network createForDeleteVoltageLevelOnLine(UUID uuid) {
         Network network = new NetworkFactoryImpl().createNetwork(uuid.toString(), "NetworkForDeleteVoltageLevelOnLine");

--- a/src/test/java/org/gridsuite/modification/server/utils/NetworkWithTeePoint.java
+++ b/src/test/java/org/gridsuite/modification/server/utils/NetworkWithTeePoint.java
@@ -29,27 +29,29 @@ public final class NetworkWithTeePoint {
     }
 
     /**
-     *     VL1            VL2            VL3
+     * Create a network as following:
+     * <pre>
+     *     VL1            VL2             VL3
      *
      *     ld1            g2              ld3
      *      |              |               |
      *     br1            br2             br3
-     *      |             |                |
-     *     d1             d2               d3
+     *      |              |               |
+     *     d1             d2              d3
      *      |              |               |
      *     bbs1 ----------bbs2------------bbs3
-     *            l1       |       l2
+     *              l1     |       l2
      *                     | l3
      *                     |
      *                    bbs4         VL4
-     *                    |
+     *                     |
      *                    d4
-     *                    |
+     *                     |
      *                    br4
-     *                    |
+     *                     |
      *                    ld4
+     * </pre>
      */
-
     public static Network create(UUID uuid, NetworkFactory networkFactory) {
         Network network = networkFactory.createNetwork(uuid.toString(), "NetworkWithTeePoint");
 


### PR DESCRIPTION
Fixing some javadoc badly formatted I found while developing with JetBrains (which render final html view).

Pass from  
![image](https://github.com/gridsuite/network-modification-server/assets/135599584/2cb62134-7d4e-4d94-a999-f362be1b1647)  
to  
![image](https://github.com/gridsuite/network-modification-server/assets/135599584/2f2ebf81-b16a-43ef-8b8a-abb1ecd61b31)
