### PR TITLE
Fix : save the regulation terminal when isRegulating is false

### DIFF
--- a/src/main/java/org/gridsuite/modification/server/modifications/TwoWindingsTransformerCreation.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/TwoWindingsTransformerCreation.java
@@ -139,11 +139,11 @@ public class TwoWindingsTransformerCreation extends AbstractModification {
                 phaseTapChangerInfos.getRegulatingTerminalId(),
                 phaseTapChangerInfos.getRegulatingTerminalType(),
                 phaseTapChangerInfos.getRegulatingTerminalVlId());
+        phaseTapChangerAdder.setRegulationTerminal(terminal);
 
         if (phaseTapChangerInfos.isRegulating()) {
             phaseTapChangerAdder.setRegulationValue(phaseTapChangerInfos.getRegulationValue())
-                    .setTargetDeadband(phaseTapChangerInfos.getTargetDeadband() != null ? phaseTapChangerInfos.getTargetDeadband() : 0.)
-                    .setRegulationTerminal(terminal);
+                    .setTargetDeadband(phaseTapChangerInfos.getTargetDeadband() != null ? phaseTapChangerInfos.getTargetDeadband() : 0.);
         }
 
         phaseTapChangerAdder.setRegulating(phaseTapChangerInfos.isRegulating())


### PR DESCRIPTION
For 2WT, when `regulating` of PhaseTapChanger was false, the regulation terminal was not saved when the network modification was applied.