### PR TITLE
set stashed status for all modifications

### DIFF
--- a/src/main/java/org/gridsuite/modification/server/entities/GroovyScriptEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/GroovyScriptEntity.java
@@ -51,6 +51,7 @@ public class GroovyScriptEntity extends ModificationEntity {
                 .builder()
                 .uuid(getId())
                 .date(getDate())
+                .stashed(getStashed())
                 .script(getScript());
     }
 }

--- a/src/main/java/org/gridsuite/modification/server/entities/ModificationEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/ModificationEntity.java
@@ -76,7 +76,7 @@ public class ModificationEntity {
         }
         //We need to limit the precision to avoid database precision storage limit issue (postgres has a precision of 6 digits while h2 can go to 9)
         this.date = ZonedDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.MICROS);
-
+        this.stashed = modificationInfos.getStashed();
         assignAttributes(modificationInfos);
     }
 

--- a/src/main/java/org/gridsuite/modification/server/entities/ModificationEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/ModificationEntity.java
@@ -76,6 +76,7 @@ public class ModificationEntity {
         }
         //We need to limit the precision to avoid database precision storage limit issue (postgres has a precision of 6 digits while h2 can go to 9)
         this.date = ZonedDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.MICROS);
+        this.stashed = modificationInfos.getStashed();
         assignAttributes(modificationInfos);
     }
 
@@ -93,7 +94,6 @@ public class ModificationEntity {
 
     @SneakyThrows
     private void assignAttributes(ModificationInfos modificationInfos) {
-        this.stashed = modificationInfos.getStashed();
         this.setType(modificationInfos.getType().name());
         this.setMessageType(modificationInfos.getType().name());
         this.setMessageValues(new ObjectMapper().writeValueAsString(modificationInfos.getMapMessageValues()));

--- a/src/main/java/org/gridsuite/modification/server/entities/ModificationEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/ModificationEntity.java
@@ -76,7 +76,6 @@ public class ModificationEntity {
         }
         //We need to limit the precision to avoid database precision storage limit issue (postgres has a precision of 6 digits while h2 can go to 9)
         this.date = ZonedDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.MICROS);
-        this.stashed = modificationInfos.getStashed();
         assignAttributes(modificationInfos);
     }
 
@@ -94,6 +93,7 @@ public class ModificationEntity {
 
     @SneakyThrows
     private void assignAttributes(ModificationInfos modificationInfos) {
+        this.stashed = modificationInfos.getStashed();
         this.setType(modificationInfos.getType().name());
         this.setMessageType(modificationInfos.getType().name());
         this.setMessageValues(new ObjectMapper().writeValueAsString(modificationInfos.getMapMessageValues()));

--- a/src/main/java/org/gridsuite/modification/server/entities/equipment/creation/BatteryCreationEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/equipment/creation/BatteryCreationEntity.java
@@ -108,6 +108,7 @@ public class BatteryCreationEntity extends InjectionCreationEntity {
                 .builder()
                 .uuid(getId())
                 .date(getDate())
+                .stashed(getStashed())
                 .equipmentId(getEquipmentId())
                 .equipmentName(getEquipmentName())
                 .voltageLevelId(getVoltageLevelId())

--- a/src/main/java/org/gridsuite/modification/server/entities/equipment/creation/ConverterStationCreationEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/equipment/creation/ConverterStationCreationEntity.java
@@ -83,6 +83,7 @@ public class ConverterStationCreationEntity extends InjectionCreationEntity {
 
     public ConverterStationCreationInfos toConverterStationInfos() {
         return ConverterStationCreationInfos.builder()
+                .stashed(getStashed())
                 .equipmentId(getEquipmentId())
                 .equipmentName(getEquipmentName())
                 .lossFactor(getLossFactor())

--- a/src/main/java/org/gridsuite/modification/server/entities/equipment/creation/GeneratorCreationEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/equipment/creation/GeneratorCreationEntity.java
@@ -164,6 +164,7 @@ public class GeneratorCreationEntity extends InjectionCreationEntity {
             .builder()
             .uuid(getId())
             .date(getDate())
+            .stashed(getStashed())
             .equipmentId(getEquipmentId())
             .equipmentName(getEquipmentName())
             .voltageLevelId(getVoltageLevelId())

--- a/src/main/java/org/gridsuite/modification/server/entities/equipment/creation/LineCreationEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/equipment/creation/LineCreationEntity.java
@@ -64,6 +64,7 @@ public class LineCreationEntity extends BranchCreationEntity {
             .builder()
             .uuid(getId())
             .date(getDate())
+            .stashed(getStashed())
             .equipmentId(getEquipmentId())
             .equipmentName(getEquipmentName())
             .seriesResistance(getSeriesResistance())

--- a/src/main/java/org/gridsuite/modification/server/entities/equipment/creation/LoadCreationEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/equipment/creation/LoadCreationEntity.java
@@ -60,6 +60,7 @@ public class LoadCreationEntity extends InjectionCreationEntity {
             .builder()
             .uuid(getId())
             .date(getDate())
+            .stashed(getStashed())
             .equipmentId(getEquipmentId())
             .equipmentName(getEquipmentName())
             .voltageLevelId(getVoltageLevelId())

--- a/src/main/java/org/gridsuite/modification/server/entities/equipment/creation/ShuntCompensatorCreationEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/equipment/creation/ShuntCompensatorCreationEntity.java
@@ -69,6 +69,7 @@ public class ShuntCompensatorCreationEntity extends InjectionCreationEntity {
             .builder()
             .uuid(getId())
             .date(getDate())
+            .stashed(getStashed())
             .equipmentId(getEquipmentId())
             .equipmentName(getEquipmentName())
             .voltageLevelId(getVoltageLevelId())

--- a/src/main/java/org/gridsuite/modification/server/entities/equipment/creation/SubstationCreationEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/equipment/creation/SubstationCreationEntity.java
@@ -64,6 +64,7 @@ public class SubstationCreationEntity extends EquipmentCreationEntity {
                 .builder()
                 .uuid(getId())
                 .date(getDate())
+                .stashed(getStashed())
                 .equipmentId(getEquipmentId())
                 .equipmentName(getEquipmentName())
                 .substationCountry(getCountry())

--- a/src/main/java/org/gridsuite/modification/server/entities/equipment/creation/TwoWindingsTransformerCreationEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/equipment/creation/TwoWindingsTransformerCreationEntity.java
@@ -177,6 +177,7 @@ public class TwoWindingsTransformerCreationEntity extends BranchCreationEntity {
                 .builder()
                 .uuid(getId())
                 .date(getDate())
+                .stashed(getStashed())
                 .equipmentId(getEquipmentId())
                 .equipmentName(getEquipmentName())
                 .seriesResistance(getSeriesResistance())

--- a/src/main/java/org/gridsuite/modification/server/entities/equipment/creation/VoltageLevelCreationEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/equipment/creation/VoltageLevelCreationEntity.java
@@ -82,7 +82,6 @@ public class VoltageLevelCreationEntity extends EquipmentCreationEntity {
 
     public VoltageLevelCreationInfos toVoltageLevelCreationInfos() {
         return toVoltageLevelCreationInfosBuilder()
-                .stashed(false)
                 .build();
     }
 

--- a/src/main/java/org/gridsuite/modification/server/entities/equipment/creation/VoltageLevelCreationEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/equipment/creation/VoltageLevelCreationEntity.java
@@ -81,7 +81,9 @@ public class VoltageLevelCreationEntity extends EquipmentCreationEntity {
     }
 
     public VoltageLevelCreationInfos toVoltageLevelCreationInfos() {
-        return toVoltageLevelCreationInfosBuilder().build();
+        return toVoltageLevelCreationInfosBuilder()
+                .stashed(false)
+                .build();
     }
 
     private VoltageLevelCreationInfos.VoltageLevelCreationInfosBuilder<?, ?> toVoltageLevelCreationInfosBuilder() {
@@ -92,6 +94,7 @@ public class VoltageLevelCreationEntity extends EquipmentCreationEntity {
                 .builder()
                 .uuid(getId())
                 .date(getDate())
+                .stashed(getStashed())
                 .equipmentId(getEquipmentId())
                 .equipmentName(getEquipmentName())
                 .substationId(getSubstationId())

--- a/src/main/java/org/gridsuite/modification/server/entities/equipment/creation/VscCreationEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/equipment/creation/VscCreationEntity.java
@@ -115,10 +115,10 @@ public class VscCreationEntity extends EquipmentCreationEntity {
     private VscCreationInfos.VscCreationInfosBuilder<?, ?> toVscCreationInfosBuilder() {
         ConverterStationCreationInfos converterStationCreationInfos1 = getConverterStation1() == null ? null : getConverterStation1().toConverterStationInfos();
         ConverterStationCreationInfos converterStationCreationInfos2 = getConverterStation2() == null ? null : getConverterStation2().toConverterStationInfos();
-
         return VscCreationInfos.builder()
                 .uuid(getId())
                 .date(getDate())
+                .stashed(getStashed())
                 .equipmentId(getEquipmentId())
                 .equipmentName(getEquipmentName())
                 .activePower(getActivePower())

--- a/src/main/java/org/gridsuite/modification/server/entities/equipment/deletion/EquipmentDeletionEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/equipment/deletion/EquipmentDeletionEntity.java
@@ -57,6 +57,7 @@ public class EquipmentDeletionEntity extends EquipmentModificationEntity {
                 .builder()
                 .uuid(getId())
                 .date(getDate())
+                .stashed(getStashed())
                 .equipmentId(getEquipmentId())
                 .equipmentType(getEquipmentType());
         if (equipmentInfos != null) {

--- a/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/BatteryModificationEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/BatteryModificationEntity.java
@@ -131,6 +131,7 @@ public class BatteryModificationEntity extends InjectionModificationEntity {
                 .builder()
                 .uuid(getId())
                 .date(getDate())
+                .stashed(getStashed())
                 .equipmentId(getEquipmentId())
                 .equipmentName(AttributeModification.toAttributeModification(getEquipmentNameValue(), getEquipmentNameOp()))
                 .voltageLevelId(AttributeModification.toAttributeModification(getVoltageLevelIdValue(), getVoltageLevelIdOp()))

--- a/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/BranchStatusModificationEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/BranchStatusModificationEntity.java
@@ -53,6 +53,7 @@ public class BranchStatusModificationEntity extends EquipmentModificationEntity 
             .builder()
             .uuid(getId())
             .date(getDate())
+            .stashed(getStashed())
             .equipmentId(getEquipmentId())
             .action(getAction())
             .energizedVoltageLevelId(getEnergizedVoltageLevelId())

--- a/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/DeleteAttachingLineEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/DeleteAttachingLineEntity.java
@@ -61,6 +61,7 @@ public class DeleteAttachingLineEntity extends ModificationEntity {
                 .builder()
                 .uuid(getId())
                 .date(getDate())
+                .stashed(getStashed())
                 .lineToAttachTo1Id(getLineToAttachTo1Id())
                 .lineToAttachTo2Id(getLineToAttachTo2Id())
                 .attachedLineId(getAttachedLineId())

--- a/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/DeleteVoltageLevelOnLineEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/DeleteVoltageLevelOnLineEntity.java
@@ -59,6 +59,7 @@ public class DeleteVoltageLevelOnLineEntity extends ModificationEntity {
                 .builder()
                 .uuid(getId())
                 .date(getDate())
+                .stashed(getStashed())
                 .lineToAttachTo1Id(getLineToAttachTo1Id())
                 .lineToAttachTo2Id(getLineToAttachTo2Id())
                 .replacingLine1Id(getReplacingLine1Id())

--- a/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/GenerationDispatchEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/GenerationDispatchEntity.java
@@ -164,6 +164,7 @@ public class GenerationDispatchEntity extends ModificationEntity {
         return GenerationDispatchInfos.builder()
                 .date(getDate())
                 .uuid(getId())
+                .stashed(getStashed())
                 .lossCoefficient(getLossCoefficient())
                 .defaultOutageRate(getDefaultOutageRate())
                 .generatorsWithoutOutage(toGeneratorsFilters(generatorsWithoutOutage))

--- a/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/GeneratorModificationEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/GeneratorModificationEntity.java
@@ -270,6 +270,7 @@ public class GeneratorModificationEntity extends InjectionModificationEntity {
                 .builder()
                 .uuid(getId())
                 .date(getDate())
+                .stashed(getStashed())
                 .equipmentId(getEquipmentId())
                 .equipmentName(AttributeModification.toAttributeModification(getEquipmentNameValue(), getEquipmentNameOp()))
                 .voltageLevelId(AttributeModification.toAttributeModification(getVoltageLevelIdValue(), getVoltageLevelIdOp()))

--- a/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/GeneratorScalingEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/GeneratorScalingEntity.java
@@ -35,6 +35,7 @@ public class GeneratorScalingEntity extends ScalingEntity {
         return GeneratorScalingInfos.builder()
                 .date(getDate())
                 .uuid(getId())
+                .stashed(getStashed())
                 .variationType(getVariationType())
                 .variations(getVariations().stream()
                         .map(ScalingVariationEntity::toScalingVariationInfos)

--- a/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/LineAttachToVoltageLevelEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/LineAttachToVoltageLevelEntity.java
@@ -107,6 +107,7 @@ public class LineAttachToVoltageLevelEntity extends ModificationEntity {
                 .builder()
                 .uuid(getId())
                 .date(getDate())
+                .stashed(getStashed())
                 .lineToAttachToId(getLineToAttachToId())
                 .percent(getPercent())
                 .attachmentPointId(getAttachmentPointId())

--- a/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/LineModificationEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/LineModificationEntity.java
@@ -83,6 +83,7 @@ public class LineModificationEntity extends BranchModificationEntity {
             .builder()
             .uuid(getId())
             .date(getDate())
+            .stashed(getStashed())
             .equipmentId(getEquipmentId())
             .equipmentName(AttributeModification.toAttributeModification(getEquipmentNameValue(), getEquipmentNameOp()))
             .seriesResistance(toAttributeModification(getSeriesResistance()))

--- a/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/LineSplitWithVoltageLevelEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/LineSplitWithVoltageLevelEntity.java
@@ -89,6 +89,7 @@ public class LineSplitWithVoltageLevelEntity extends ModificationEntity {
             .builder()
             .uuid(getId())
             .date(getDate())
+            .stashed(getStashed())
             .lineToSplitId(getLineToSplitId())
             .percent(getPercent())
             .mayNewVoltageLevelInfos(mayVoltageLevelCreation == null ? null : mayVoltageLevelCreation.toVoltageLevelCreationInfos())

--- a/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/LinesAttachToSplitLinesEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/LinesAttachToSplitLinesEntity.java
@@ -86,6 +86,7 @@ public class LinesAttachToSplitLinesEntity extends ModificationEntity {
                 .builder()
                 .uuid(getId())
                 .date(getDate())
+                .stashed(getStashed())
                 .lineToAttachTo1Id(getLineToAttachTo1Id())
                 .lineToAttachTo2Id(getLineToAttachTo2Id())
                 .attachedLineId(getAttachedLineId())

--- a/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/LoadModificationEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/LoadModificationEntity.java
@@ -77,6 +77,7 @@ public class LoadModificationEntity extends InjectionModificationEntity {
                 .builder()
                 .uuid(getId())
                 .date(getDate())
+                .stashed(getStashed())
                 .equipmentId(getEquipmentId())
                 .equipmentName(AttributeModification.toAttributeModification(getEquipmentNameValue(), getEquipmentNameOp()))
                 .voltageLevelId(AttributeModification.toAttributeModification(getVoltageLevelIdValue(), getVoltageLevelIdOp()))

--- a/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/LoadScalingEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/LoadScalingEntity.java
@@ -36,6 +36,7 @@ public class LoadScalingEntity extends ScalingEntity {
                 .builder()
                 .uuid(getId())
                 .date(getDate())
+                .stashed(getStashed())
                 .variationType(getVariationType())
                 .variations(getVariations().stream()
                         .map(ScalingVariationEntity::toScalingVariationInfos)

--- a/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/ShuntCompensatorModificationEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/ShuntCompensatorModificationEntity.java
@@ -86,6 +86,7 @@ public class ShuntCompensatorModificationEntity extends BasicEquipmentModificati
                 .builder()
                 .uuid(getId())
                 .date(getDate())
+                .stashed(getStashed())
                 .voltageLevelId(getVoltageLevelId())
                 .equipmentId(getEquipmentId())
                 .equipmentName(toAttributeModification(getEquipmentNameValue(), getEquipmentNameOp()))

--- a/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/SubstationModificationEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/SubstationModificationEntity.java
@@ -79,6 +79,7 @@ public class SubstationModificationEntity extends BasicEquipmentModificationEnti
                 .builder()
                 .uuid(getId())
                 .date(getDate())
+                .stashed(getStashed())
                 .equipmentId(getEquipmentId())
                 .equipmentName(AttributeModification.toAttributeModification(getEquipmentNameValue(), getEquipmentNameOp()))
                 .substationCountry(AttributeModification.toAttributeModification(getSubstationCountryValue(), getSubstationCountryOp()))

--- a/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/TwoWindingsTransformerModificationEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/TwoWindingsTransformerModificationEntity.java
@@ -348,6 +348,7 @@ public class TwoWindingsTransformerModificationEntity extends BranchModification
                 .builder()
                 .uuid(getId())
                 .date(getDate())
+                .stashed(getStashed())
                 .equipmentId(getEquipmentId())
                 .equipmentName(AttributeModification.toAttributeModification(getEquipmentNameValue(), getEquipmentNameOp()))
                 .seriesResistance(AttributeModification.toAttributeModification(getSeriesResistance()))

--- a/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/VoltageInitModificationEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/VoltageInitModificationEntity.java
@@ -157,6 +157,7 @@ public class VoltageInitModificationEntity extends ModificationEntity {
         return VoltageInitModificationInfos.builder()
             .date(getDate())
             .uuid(getId())
+            .stashed(getStashed())
             .generators(toGeneratorsModification(generators))
             .transformers(toTransformersModification(transformers))
             .staticVarCompensators(toStaticVarCompensatorsModification(staticVarCompensators))

--- a/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/VoltageLevelModificationEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/VoltageLevelModificationEntity.java
@@ -99,6 +99,7 @@ public class VoltageLevelModificationEntity extends BasicEquipmentModificationEn
                 .uuid(getId())
                 .equipmentId(getEquipmentId())
                 .date(getDate())
+                .stashed(getStashed())
                 .equipmentName(toAttributeModification(getEquipmentNameValue(), getEquipmentNameOp()))
                 .nominalVoltage(toAttributeModification(getNominalVoltage()))
                 .lowVoltageLimit(toAttributeModification(getLowVoltageLimit()))

--- a/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/attribute/EquipmentAttributeModificationEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/attribute/EquipmentAttributeModificationEntity.java
@@ -69,6 +69,7 @@ public class EquipmentAttributeModificationEntity<T> extends EquipmentModificati
             .builder()
             .uuid(getId())
             .date(getDate())
+            .stashed(getStashed())
             .equipmentId(getEquipmentId())
             .equipmentAttributeName(getAttributeName())
             .equipmentAttributeValue(getAttributeValue())

--- a/src/test/java/org/gridsuite/modification/server/ModificationControllerTest.java
+++ b/src/test/java/org/gridsuite/modification/server/ModificationControllerTest.java
@@ -1224,6 +1224,7 @@ public class ModificationControllerTest {
     public void testCreateVoltageInitModification() throws Exception {
         // Create the modification
         VoltageInitModificationInfos modificationsInfos1 = VoltageInitModificationInfos.builder()
+            .stashed(false)
             .generators(List.of(
                 VoltageInitGeneratorModificationInfos.builder()
                     .generatorId("G1")

--- a/src/test/java/org/gridsuite/modification/server/modifications/BatteryCreationInBusBreakerTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/BatteryCreationInBusBreakerTest.java
@@ -41,6 +41,7 @@ public class BatteryCreationInBusBreakerTest extends AbstractNetworkModification
     @Override
     protected ModificationInfos buildModification() {
         return BatteryCreationInfos.builder()
+                .stashed(false)
                 .equipmentId("idBattery2")
                 .equipmentName("nameBattery2")
                 .voltageLevelId("v1")
@@ -64,6 +65,7 @@ public class BatteryCreationInBusBreakerTest extends AbstractNetworkModification
     @Override
     protected ModificationInfos buildModificationUpdate() {
         return BatteryCreationInfos.builder()
+                .stashed(false)
                 .equipmentId("idBattery2Edited")
                 .equipmentName("nameBatteryModified")
                 .voltageLevelId("v1")

--- a/src/test/java/org/gridsuite/modification/server/modifications/BatteryCreationInNodeBreakerTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/BatteryCreationInNodeBreakerTest.java
@@ -45,6 +45,7 @@ public class BatteryCreationInNodeBreakerTest extends AbstractNetworkModificatio
     protected ModificationInfos buildModification() {
         // create new battery in voltage level with node/breaker topology (in voltage level "v2" and busbar section "1B")
         return BatteryCreationInfos.builder()
+                .stashed(false)
                 .equipmentId("idBattery1")
                 .equipmentName("idBattery1")
                 .voltageLevelId("v2")
@@ -68,6 +69,7 @@ public class BatteryCreationInNodeBreakerTest extends AbstractNetworkModificatio
     @Override
     protected ModificationInfos buildModificationUpdate() {
         return BatteryCreationInfos.builder()
+                .stashed(false)
                 .equipmentId("idBattery2Edited")
                 .equipmentName("nameBatteryModified")
                 .voltageLevelId("v1")

--- a/src/test/java/org/gridsuite/modification/server/modifications/BatteryModificationTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/BatteryModificationTest.java
@@ -38,6 +38,7 @@ public class BatteryModificationTest extends AbstractNetworkModificationTest {
     @Override
     protected ModificationInfos buildModification() {
         return BatteryModificationInfos.builder()
+                .stashed(false)
                 .equipmentId("v3Battery")
                 .equipmentName(new AttributeModification<>("newV1Battery", OperationType.SET))
                 .activePowerSetpoint(new AttributeModification<>(80.0, OperationType.SET))
@@ -58,6 +59,7 @@ public class BatteryModificationTest extends AbstractNetworkModificationTest {
     @Override
     protected ModificationInfos buildModificationUpdate() {
         return BatteryModificationInfos.builder()
+                .stashed(false)
                 .equipmentId("idBatteryEdited")
                 .equipmentName(new AttributeModification<>("newV1BatteryEdited", OperationType.SET))
                 .activePowerSetpoint(new AttributeModification<>(81.0, OperationType.SET))

--- a/src/test/java/org/gridsuite/modification/server/modifications/BranchStatusModificationEnergiseSideOneLineTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/BranchStatusModificationEnergiseSideOneLineTest.java
@@ -47,6 +47,7 @@ public class BranchStatusModificationEnergiseSideOneLineTest extends AbstractNet
     @Override
     protected ModificationInfos buildModification() {
         return BranchStatusModificationInfos.builder()
+                .stashed(false)
                 .equipmentId(TARGET_LINE_ID)
                 .energizedVoltageLevelId("vl1")
                 .action(BranchStatusModificationInfos.ActionType.ENERGISE_END_ONE).build();
@@ -55,6 +56,7 @@ public class BranchStatusModificationEnergiseSideOneLineTest extends AbstractNet
     @Override
     protected ModificationInfos buildModificationUpdate() {
         return BranchStatusModificationInfos.builder()
+                .stashed(false)
                 .equipmentId("line1")
                 .energizedVoltageLevelId("vl1_bis")
                 .action(BranchStatusModificationInfos.ActionType.TRIP)

--- a/src/test/java/org/gridsuite/modification/server/modifications/BranchStatusModificationEnergiseSideTwoLineTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/BranchStatusModificationEnergiseSideTwoLineTest.java
@@ -47,6 +47,7 @@ public class BranchStatusModificationEnergiseSideTwoLineTest extends AbstractNet
     @Override
     protected ModificationInfos buildModification() {
         return BranchStatusModificationInfos.builder()
+                .stashed(false)
                 .equipmentId(TARGET_LINE_ID)
                 .energizedVoltageLevelId("vl2")
                 .action(BranchStatusModificationInfos.ActionType.ENERGISE_END_TWO).build();
@@ -55,6 +56,7 @@ public class BranchStatusModificationEnergiseSideTwoLineTest extends AbstractNet
     @Override
     protected ModificationInfos buildModificationUpdate() {
         return BranchStatusModificationInfos.builder()
+                .stashed(false)
                 .equipmentId("line1")
                 .energizedVoltageLevelId("vl2_bis")
                 .action(BranchStatusModificationInfos.ActionType.TRIP).build();

--- a/src/test/java/org/gridsuite/modification/server/modifications/BranchStatusModificationLockoutLineTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/BranchStatusModificationLockoutLineTest.java
@@ -51,6 +51,7 @@ public class BranchStatusModificationLockoutLineTest extends AbstractNetworkModi
     @Override
     protected ModificationInfos buildModification() {
         return BranchStatusModificationInfos.builder()
+                .stashed(false)
                 .equipmentId(TARGET_LINE_ID)
                 .energizedVoltageLevelId("energizedVoltageLevelId")
                 .action(BranchStatusModificationInfos.ActionType.LOCKOUT).build();
@@ -59,6 +60,7 @@ public class BranchStatusModificationLockoutLineTest extends AbstractNetworkModi
     @Override
     protected ModificationInfos buildModificationUpdate() {
         return BranchStatusModificationInfos.builder()
+                .stashed(false)
                 .equipmentId(UPDATE_BRANCH_ID)
                 .energizedVoltageLevelId("energizedVoltageLevelId")
                 .action(BranchStatusModificationInfos.ActionType.SWITCH_ON).build();

--- a/src/test/java/org/gridsuite/modification/server/modifications/BranchStatusModificationSwitchOnLineTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/BranchStatusModificationSwitchOnLineTest.java
@@ -41,6 +41,7 @@ public class BranchStatusModificationSwitchOnLineTest extends AbstractNetworkMod
     @Override
     protected ModificationInfos buildModification() {
         return BranchStatusModificationInfos.builder()
+                .stashed(false)
                 .equipmentId(TARGET_LINE_ID)
                 .energizedVoltageLevelId("energizedVoltageLevelId")
                 .action(BranchStatusModificationInfos.ActionType.SWITCH_ON).build();
@@ -51,6 +52,7 @@ public class BranchStatusModificationSwitchOnLineTest extends AbstractNetworkMod
         return BranchStatusModificationInfos.builder()
                 .equipmentId("line1Edited")
                 .energizedVoltageLevelId("energizedVoltageLevelIdEdited")
+                .stashed(false)
                 .action(BranchStatusModificationInfos.ActionType.TRIP).build();
     }
 

--- a/src/test/java/org/gridsuite/modification/server/modifications/BranchStatusModificationTrip2WTransformerTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/BranchStatusModificationTrip2WTransformerTest.java
@@ -42,6 +42,7 @@ public class BranchStatusModificationTrip2WTransformerTest extends AbstractNetwo
     @Override
     protected ModificationInfos buildModification() {
         return BranchStatusModificationInfos.builder()
+                .stashed(false)
                 .equipmentId(TARGET_BRANCH_ID)
                 .energizedVoltageLevelId("energizedVoltageLevelId")
                 .action(BranchStatusModificationInfos.ActionType.TRIP).build();
@@ -50,6 +51,7 @@ public class BranchStatusModificationTrip2WTransformerTest extends AbstractNetwo
     @Override
     protected ModificationInfos buildModificationUpdate() {
         return BranchStatusModificationInfos.builder()
+                .stashed(false)
                 .equipmentId(UPDATE_BRANCH_ID)
                 .energizedVoltageLevelId("energizedVoltageLevelIdEdited")
                 .action(BranchStatusModificationInfos.ActionType.SWITCH_ON).build();

--- a/src/test/java/org/gridsuite/modification/server/modifications/BranchStatusModificationTripLineTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/BranchStatusModificationTripLineTest.java
@@ -42,6 +42,7 @@ public class BranchStatusModificationTripLineTest extends AbstractNetworkModific
     @Override
     protected ModificationInfos buildModification() {
         return BranchStatusModificationInfos.builder()
+                .stashed(false)
                 .equipmentId(TARGET_LINE_ID)
                 .energizedVoltageLevelId("energizedVoltageLevelId")
                 .action(BranchStatusModificationInfos.ActionType.TRIP).build();
@@ -50,6 +51,7 @@ public class BranchStatusModificationTripLineTest extends AbstractNetworkModific
     @Override
     protected ModificationInfos buildModificationUpdate() {
         return BranchStatusModificationInfos.builder()
+                .stashed(false)
                 .equipmentId(UPDATE_BRANCH_ID)
                 .energizedVoltageLevelId("energizedVoltageLevelIdEdited")
                 .action(BranchStatusModificationInfos.ActionType.SWITCH_ON).build();

--- a/src/test/java/org/gridsuite/modification/server/modifications/DeleteAttachingLineTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/DeleteAttachingLineTest.java
@@ -44,6 +44,7 @@ public class DeleteAttachingLineTest extends AbstractNetworkModificationTest {
     @Override
     protected ModificationInfos buildModification() {
         return DeleteAttachingLineInfos.builder()
+                .stashed(false)
                 .lineToAttachTo1Id("l1")
                 .lineToAttachTo2Id("l2")
                 .attachedLineId("l3")
@@ -55,6 +56,7 @@ public class DeleteAttachingLineTest extends AbstractNetworkModificationTest {
     @Override
     protected ModificationInfos buildModificationUpdate() {
         return DeleteAttachingLineInfos.builder()
+                .stashed(false)
                 .lineToAttachTo1Id("l1")
                 .lineToAttachTo2Id("l2")
                 .attachedLineId("l3")
@@ -81,6 +83,7 @@ public class DeleteAttachingLineTest extends AbstractNetworkModificationTest {
     public void createWithInvalidLineIdTest() throws Exception {
         // test create with incorrect line id
         DeleteAttachingLineInfos deleteAttachingLineInfos = DeleteAttachingLineInfos.builder()
+                .stashed(false)
                 .lineToAttachTo1Id("l1")
                 .lineToAttachTo2Id("ll")
                 .attachedLineId("l2")
@@ -97,6 +100,7 @@ public class DeleteAttachingLineTest extends AbstractNetworkModificationTest {
     @Test
     public void createWithNoAttachmentPointTest() throws Exception {
         DeleteAttachingLineInfos deleteAttachingLineInfos = DeleteAttachingLineInfos.builder()
+                .stashed(false)
                 .lineToAttachTo1Id("l1")
                 .lineToAttachTo2Id("l3")
                 .attachedLineId("l1")

--- a/src/test/java/org/gridsuite/modification/server/modifications/DeleteVoltageLevelOnLineTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/DeleteVoltageLevelOnLineTest.java
@@ -44,6 +44,7 @@ public class DeleteVoltageLevelOnLineTest extends AbstractNetworkModificationTes
     @Override
     protected ModificationInfos buildModification() {
         return DeleteVoltageLevelOnLineInfos.builder()
+               .stashed(false)
                .lineToAttachTo1Id("l1")
                .lineToAttachTo2Id("l2")
                .replacingLine1Id("replacementLineId")
@@ -54,6 +55,7 @@ public class DeleteVoltageLevelOnLineTest extends AbstractNetworkModificationTes
     @Override
     protected ModificationInfos buildModificationUpdate() {
         return DeleteVoltageLevelOnLineInfos.builder()
+                .stashed(false)
                 .lineToAttachTo1Id("line00")
                 .lineToAttachTo2Id("line11")
                 .replacingLine1Id("replacingLineId2")
@@ -83,6 +85,7 @@ public class DeleteVoltageLevelOnLineTest extends AbstractNetworkModificationTes
     public void createWithInvalidLineIdTest() throws Exception {
         // test create with incorrect line id
         DeleteVoltageLevelOnLineInfos deleteVoltageLevelOnLineInfos = DeleteVoltageLevelOnLineInfos.builder()
+                .stashed(false)
                 .lineToAttachTo1Id("l1")
                 .lineToAttachTo2Id("ll")
                 .replacingLine1Id("replacementLineId")

--- a/src/test/java/org/gridsuite/modification/server/modifications/EquipmentAttributeModificationTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/EquipmentAttributeModificationTest.java
@@ -45,6 +45,7 @@ public class EquipmentAttributeModificationTest extends AbstractNetworkModificat
         UUID modificationUuid = UUID.randomUUID();
         //We need to limit the precision to avoid database precision storage limit issue (postgres has a precision of 6 digits while h2 can go to 9)
         EquipmentAttributeModificationInfos modificationInfos = EquipmentAttributeModificationInfos.builder()
+            .stashed(false)
             .uuid(modificationUuid)
             .date(ZonedDateTime.of(2021, 2, 19, 0, 0, 0, 0, ZoneOffset.UTC).truncatedTo(ChronoUnit.MICROS))
             .equipmentId("equipmentId")
@@ -52,9 +53,10 @@ public class EquipmentAttributeModificationTest extends AbstractNetworkModificat
             .equipmentAttributeValue("equipmentAttributeValue")
             .equipmentType(IdentifiableType.VOLTAGE_LEVEL)
             .build();
-        assertEquals(String.format("EquipmentAttributeModificationInfos(super=EquipmentModificationInfos(super=ModificationInfos(uuid=%s, type=EQUIPMENT_ATTRIBUTE_MODIFICATION, date=2021-02-19T00:00Z, stashed=null, messageType=null, messageValues=null), equipmentId=equipmentId), equipmentAttributeName=equipmentAttributeName, equipmentAttributeValue=equipmentAttributeValue, equipmentType=VOLTAGE_LEVEL)", modificationUuid), modificationInfos.toString());
+        assertEquals(String.format("EquipmentAttributeModificationInfos(super=EquipmentModificationInfos(super=ModificationInfos(uuid=%s, type=EQUIPMENT_ATTRIBUTE_MODIFICATION, date=2021-02-19T00:00Z, stashed=false, messageType=null, messageValues=null), equipmentId=equipmentId), equipmentAttributeName=equipmentAttributeName, equipmentAttributeValue=equipmentAttributeValue, equipmentType=VOLTAGE_LEVEL)", modificationUuid), modificationInfos.toString());
 
         EquipmentAttributeModificationInfos switchStatusModificationInfos = EquipmentAttributeModificationInfos.builder()
+            .stashed(false)
             .equipmentType(IdentifiableType.SWITCH)
             .equipmentAttributeName("open")
             .equipmentAttributeValue(true)
@@ -133,6 +135,7 @@ public class EquipmentAttributeModificationTest extends AbstractNetworkModificat
     public void testWithErrors() throws Exception {
         // bad equipment attribute name
         EquipmentAttributeModificationInfos switchStatusModificationInfos = EquipmentAttributeModificationInfos.builder()
+            .stashed(false)
             .equipmentType(IdentifiableType.SWITCH)
             .equipmentAttributeName("close") // bad
             .equipmentAttributeValue(true)
@@ -163,6 +166,7 @@ public class EquipmentAttributeModificationTest extends AbstractNetworkModificat
     @Override
     protected EquipmentAttributeModificationInfos buildModification() {
         return EquipmentAttributeModificationInfos.builder()
+            .stashed(false)
             .equipmentType(IdentifiableType.SWITCH)
             .equipmentAttributeName("open")
             .equipmentAttributeValue(true)
@@ -173,6 +177,7 @@ public class EquipmentAttributeModificationTest extends AbstractNetworkModificat
     @Override
     protected EquipmentAttributeModificationInfos buildModificationUpdate() {
         return EquipmentAttributeModificationInfos.builder()
+            .stashed(false)
             .equipmentType(IdentifiableType.SWITCH)
             .equipmentAttributeName("open")
             .equipmentAttributeValue(false)

--- a/src/test/java/org/gridsuite/modification/server/modifications/EquipmentDeletionTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/EquipmentDeletionTest.java
@@ -50,6 +50,7 @@ public class EquipmentDeletionTest extends AbstractNetworkModificationTest {
     @Override
     protected ModificationInfos buildModification() {
         return EquipmentDeletionInfos.builder()
+                .stashed(false)
                 .equipmentType("LOAD")
                 .equipmentId("v1load")
                 .build();
@@ -58,6 +59,7 @@ public class EquipmentDeletionTest extends AbstractNetworkModificationTest {
     @Override
     protected ModificationInfos buildModificationUpdate() {
         return EquipmentDeletionInfos.builder()
+                .stashed(false)
                 .equipmentType("GENERATOR")
                 .equipmentId("idGenerator")
                 .build();
@@ -77,6 +79,7 @@ public class EquipmentDeletionTest extends AbstractNetworkModificationTest {
     public void testOkWhenRemovingIsolatedEquipment() throws Exception {
 
         EquipmentDeletionInfos equipmentDeletionInfos = EquipmentDeletionInfos.builder()
+                .stashed(false)
                 .equipmentType("LOAD")
                 .equipmentId("v5load")
                 .build();
@@ -117,6 +120,7 @@ public class EquipmentDeletionTest extends AbstractNetworkModificationTest {
                 new HvdcLccDeletionInfos(shuntData, null) :
                 new HvdcLccDeletionInfos(null, shuntData);
         EquipmentDeletionInfos equipmentDeletionInfos = EquipmentDeletionInfos.builder()
+                .stashed(false)
                 .equipmentType("HVDC_LINE")
                 .equipmentId(hvdcLineName)
                 .equipmentInfos(hvdcLccDeletionInfos)

--- a/src/test/java/org/gridsuite/modification/server/modifications/GenerationDispatchTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/GenerationDispatchTest.java
@@ -574,6 +574,7 @@ public class GenerationDispatchTest extends AbstractNetworkModificationTest {
     @Override
     protected ModificationInfos buildModification() {
         return GenerationDispatchInfos.builder()
+            .stashed(false)
             .lossCoefficient(20.)
             .defaultOutageRate(0.)
             .generatorsWithoutOutage(List.of())
@@ -586,6 +587,7 @@ public class GenerationDispatchTest extends AbstractNetworkModificationTest {
     @Override
     protected ModificationInfos buildModificationUpdate() {
         return GenerationDispatchInfos.builder()
+            .stashed(false)
             .lossCoefficient(50.)
             .defaultOutageRate(25.)
             .generatorsWithoutOutage(List.of(GeneratorsFilterInfos.builder().id(UUID.randomUUID()).name("name1").build()))

--- a/src/test/java/org/gridsuite/modification/server/modifications/GeneratorCreationInBusBreakerTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/GeneratorCreationInBusBreakerTest.java
@@ -43,6 +43,7 @@ public class GeneratorCreationInBusBreakerTest extends AbstractNetworkModificati
     @Override
     protected ModificationInfos buildModification() {
         return GeneratorCreationInfos.builder()
+                .stashed(false)
                 .equipmentId("idGenerator2")
                 .equipmentName("nameGenerator2")
                 .voltageLevelId("v1")
@@ -81,6 +82,7 @@ public class GeneratorCreationInBusBreakerTest extends AbstractNetworkModificati
     protected ModificationInfos buildModificationUpdate() {
         return GeneratorCreationInfos.builder()
                 .equipmentId("idGenerator2Edited")
+                .stashed(false)
                 .equipmentName("nameGeneratorModified")
                 .voltageLevelId("v1")
                 .busOrBusbarSectionId("bus1")

--- a/src/test/java/org/gridsuite/modification/server/modifications/GeneratorCreationInNodeBreakerTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/GeneratorCreationInNodeBreakerTest.java
@@ -46,6 +46,7 @@ public class GeneratorCreationInNodeBreakerTest extends AbstractNetworkModificat
     protected ModificationInfos buildModification() {
         // create new generator in voltage level with node/breaker topology (in voltage level "v2" and busbar section "1B")
         return GeneratorCreationInfos.builder()
+                .stashed(false)
                 .equipmentId("idGenerator1")
                 .equipmentName("idGenerator1")
                 .voltageLevelId("v2")
@@ -83,6 +84,7 @@ public class GeneratorCreationInNodeBreakerTest extends AbstractNetworkModificat
     @Override
     protected ModificationInfos buildModificationUpdate() {
         return GeneratorCreationInfos.builder()
+                .stashed(false)
                 .equipmentId("idGenerator2")
                 .equipmentName("nameGeneratorModified")
                 .voltageLevelId("v1")

--- a/src/test/java/org/gridsuite/modification/server/modifications/GeneratorModificationTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/GeneratorModificationTest.java
@@ -40,6 +40,7 @@ public class GeneratorModificationTest extends AbstractNetworkModificationTest {
     @Override
     protected ModificationInfos buildModification() {
         return GeneratorModificationInfos.builder()
+                .stashed(false)
                 .equipmentId("idGenerator")
                 .energySource(new AttributeModification<>(EnergySource.SOLAR, OperationType.SET))
                 .equipmentName(new AttributeModification<>("newV1Generator", OperationType.SET))
@@ -77,6 +78,7 @@ public class GeneratorModificationTest extends AbstractNetworkModificationTest {
     protected ModificationInfos buildModificationUpdate() {
         return GeneratorModificationInfos.builder()
                 .equipmentId("idGeneratorEdited")
+                .stashed(false)
                 .energySource(new AttributeModification<>(EnergySource.HYDRO, OperationType.SET))
                 .equipmentName(new AttributeModification<>("newV1GeneratorEdited", OperationType.SET))
                 .activePowerSetpoint(new AttributeModification<>(81.0, OperationType.SET))

--- a/src/test/java/org/gridsuite/modification/server/modifications/GeneratorScalingTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/GeneratorScalingTest.java
@@ -119,7 +119,7 @@ public class GeneratorScalingTest extends AbstractNetworkModificationTest {
         wireMockUtils.verifyGetRequest(stubId, PATH, handleQueryParams(getNetworkUuid(), filters.stream().map(FilterEquipments::getFilterId).collect(Collectors.toList())), false);
 
         assertEquals(
-            String.format("ScalingInfos(super=ModificationInfos(uuid=null, type=GENERATOR_SCALING, date=null, stashed=null, messageType=null, messageValues=null), variations=[ScalingVariationInfos(id=null, filters=[FilterInfos(id=%s, name=filter1)], variationMode=PROPORTIONAL_TO_PMAX, variationValue=50.0, reactiveVariationMode=null), ScalingVariationInfos(id=null, filters=[FilterInfos(id=%s, name=filter2)], variationMode=REGULAR_DISTRIBUTION, variationValue=50.0, reactiveVariationMode=null), ScalingVariationInfos(id=null, filters=[FilterInfos(id=%s, name=filter3)], variationMode=STACKING_UP, variationValue=50.0, reactiveVariationMode=null), ScalingVariationInfos(id=null, filters=[FilterInfos(id=%s, name=filter4)], variationMode=VENTILATION, variationValue=50.0, reactiveVariationMode=null), ScalingVariationInfos(id=null, filters=[FilterInfos(id=%s, name=filter1), FilterInfos(id=%s, name=filter5)], variationMode=PROPORTIONAL, variationValue=50.0, reactiveVariationMode=null)], variationType=DELTA_P)",
+            String.format("ScalingInfos(super=ModificationInfos(uuid=null, type=GENERATOR_SCALING, date=null, stashed=false, messageType=null, messageValues=null), variations=[ScalingVariationInfos(id=null, filters=[FilterInfos(id=%s, name=filter1)], variationMode=PROPORTIONAL_TO_PMAX, variationValue=50.0, reactiveVariationMode=null), ScalingVariationInfos(id=null, filters=[FilterInfos(id=%s, name=filter2)], variationMode=REGULAR_DISTRIBUTION, variationValue=50.0, reactiveVariationMode=null), ScalingVariationInfos(id=null, filters=[FilterInfos(id=%s, name=filter3)], variationMode=STACKING_UP, variationValue=50.0, reactiveVariationMode=null), ScalingVariationInfos(id=null, filters=[FilterInfos(id=%s, name=filter4)], variationMode=VENTILATION, variationValue=50.0, reactiveVariationMode=null), ScalingVariationInfos(id=null, filters=[FilterInfos(id=%s, name=filter1), FilterInfos(id=%s, name=filter5)], variationMode=PROPORTIONAL, variationValue=50.0, reactiveVariationMode=null)], variationType=DELTA_P)",
                 FILTER_ID_1, FILTER_ID_2, FILTER_ID_3, FILTER_ID_4, FILTER_ID_1, FILTER_ID_5),
             buildModification().toString()
         );
@@ -162,6 +162,7 @@ public class GeneratorScalingTest extends AbstractNetworkModificationTest {
                 .build();
 
         ModificationInfos modificationToCreate = GeneratorScalingInfos.builder()
+                .stashed(false)
                 .uuid(GENERATOR_SCALING_ID)
                 .date(ZonedDateTime.now().truncatedTo(ChronoUnit.MICROS))
                 .variationType(VariationType.DELTA_P)
@@ -197,6 +198,7 @@ public class GeneratorScalingTest extends AbstractNetworkModificationTest {
                 .filters(List.of(filter))
                 .build();
         var generatorScalingInfo = GeneratorScalingInfos.builder()
+                .stashed(false)
                 .variationType(VariationType.TARGET_P)
                 .variations(List.of(variation))
                 .build();
@@ -239,6 +241,7 @@ public class GeneratorScalingTest extends AbstractNetworkModificationTest {
                 .filters(List.of(filter, filter2))
                 .build();
         var generatorScalingInfo = GeneratorScalingInfos.builder()
+                .stashed(false)
                 .variationType(VariationType.TARGET_P)
                 .variations(List.of(variation))
                 .build();
@@ -321,6 +324,7 @@ public class GeneratorScalingTest extends AbstractNetworkModificationTest {
                 .build();
 
         return GeneratorScalingInfos.builder()
+                .stashed(false)
                 //.date(ZonedDateTime.now().truncatedTo(ChronoUnit.MICROS))
                 .variationType(VariationType.DELTA_P)
                 .variations(List.of(variation1, variation2, variation3, variation4, variation5))
@@ -341,6 +345,7 @@ public class GeneratorScalingTest extends AbstractNetworkModificationTest {
                 .build();
 
         return GeneratorScalingInfos.builder()
+                .stashed(false)
                 .uuid(GENERATOR_SCALING_ID)
                 //.date(ZonedDateTime.now().truncatedTo(ChronoUnit.MICROS))
                 .variationType(VariationType.TARGET_P)

--- a/src/test/java/org/gridsuite/modification/server/modifications/GroovyScriptTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/GroovyScriptTest.java
@@ -39,6 +39,7 @@ public class GroovyScriptTest extends AbstractNetworkModificationTest {
     @Override
     protected ModificationInfos buildModification() {
         return GroovyScriptInfos.builder()
+                .stashed(false)
                 .script("network.getGenerator('idGenerator').targetP=12\n")
                 .build();
     }
@@ -46,6 +47,7 @@ public class GroovyScriptTest extends AbstractNetworkModificationTest {
     @Override
     protected ModificationInfos buildModificationUpdate() {
         return GroovyScriptInfos.builder()
+                .stashed(false)
                 .script("network.getGenerator('idGenerator').targetP=15\n")
                 .build();
     }
@@ -65,6 +67,7 @@ public class GroovyScriptTest extends AbstractNetworkModificationTest {
         MvcResult mvcResult;
 
         GroovyScriptInfos groovyScriptInfos = GroovyScriptInfos.builder()
+                .stashed(false)
                 .script("network.getGenerator('idGenerator').targetP=12\n")
                 .build();
         String groovyScriptInfosJson = mapper.writeValueAsString(groovyScriptInfos);

--- a/src/test/java/org/gridsuite/modification/server/modifications/LineAttachToNewVoltageLevelTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/LineAttachToNewVoltageLevelTest.java
@@ -30,6 +30,7 @@ public class LineAttachToNewVoltageLevelTest extends AbstractNetworkModification
 
     private LineCreationInfos getAttachmentLine() {
         return LineCreationInfos.builder()
+                .stashed(false)
                 .equipmentId("attachmentLine")
                 .seriesResistance(50.6)
                 .seriesReactance(25.3)
@@ -38,6 +39,7 @@ public class LineAttachToNewVoltageLevelTest extends AbstractNetworkModification
 
     private VoltageLevelCreationInfos getNewVoltageLevel() {
         return VoltageLevelCreationInfos.builder()
+                .stashed(false)
                 .equipmentId("newVoltageLevel")
                 .equipmentName("NewVoltageLevel")
                 .nominalVoltage(379.3)
@@ -61,6 +63,7 @@ public class LineAttachToNewVoltageLevelTest extends AbstractNetworkModification
     @Override
     protected ModificationInfos buildModification() {
         return LineAttachToVoltageLevelInfos.builder()
+                .stashed(false)
                 .lineToAttachToId("line3")
                 .percent(20.0)
                 .attachmentPointId("AttPointId")
@@ -80,6 +83,7 @@ public class LineAttachToNewVoltageLevelTest extends AbstractNetworkModification
     protected ModificationInfos buildModificationUpdate() {
         return LineAttachToVoltageLevelInfos.builder()
                 .lineToAttachToId("line3Edited")
+                .stashed(false)
                 .percent(10.0)
                 .attachmentPointId("AttPointId")   // created VL
                 .attachmentPointName("attPointName")

--- a/src/test/java/org/gridsuite/modification/server/modifications/LineAttachToVoltageLevelTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/LineAttachToVoltageLevelTest.java
@@ -38,6 +38,7 @@ public class LineAttachToVoltageLevelTest extends AbstractNetworkModificationTes
 
     private LineCreationInfos getAttachmentLine(String lineName) {
         return LineCreationInfos.builder()
+                .stashed(false)
                 .equipmentId(lineName)
                 .seriesResistance(50.6)
                 .seriesReactance(25.3)
@@ -46,6 +47,7 @@ public class LineAttachToVoltageLevelTest extends AbstractNetworkModificationTes
 
     private VoltageLevelCreationInfos getNewVoltageLevel() {
         return VoltageLevelCreationInfos.builder()
+                .stashed(false)
                 .equipmentId("newVoltageLevel")
                 .equipmentName("NewVoltageLevel")
                 .nominalVoltage(379.3)
@@ -69,6 +71,7 @@ public class LineAttachToVoltageLevelTest extends AbstractNetworkModificationTes
     @Override
     protected ModificationInfos buildModification() {
         return LineAttachToVoltageLevelInfos.builder()
+                .stashed(false)
                 .lineToAttachToId("line3")
                 .percent(10.0)
                 .attachmentPointId("AttPointId")   // created VL
@@ -87,6 +90,7 @@ public class LineAttachToVoltageLevelTest extends AbstractNetworkModificationTes
     @Override
     protected ModificationInfos buildModificationUpdate() {
         return LineAttachToVoltageLevelInfos.builder()
+                .stashed(false)
                 .lineToAttachToId("line2")
                 .percent(30.0)
                 .attachmentPointId("newAttPointId")

--- a/src/test/java/org/gridsuite/modification/server/modifications/LineCreationInBusBreakerTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/LineCreationInBusBreakerTest.java
@@ -50,6 +50,7 @@ public class LineCreationInBusBreakerTest extends AbstractNetworkModificationTes
     public void testCreateLineOptionalParameters() throws Exception {
         // create new line without shunt conductance or reactance
         LineCreationInfos lineCreationInfosNoShunt = LineCreationInfos.builder()
+                .stashed(false)
                 .equipmentId("idLine1")
                 .equipmentName("nameLine1")
                 .seriesResistance(100.0)
@@ -73,6 +74,7 @@ public class LineCreationInBusBreakerTest extends AbstractNetworkModificationTes
     public void testCreateLineOptionalParameters2() throws Exception {
         // create new line without shunt conductance or reactance
         LineCreationInfos lineCreationInfosNoShunt = LineCreationInfos.builder()
+                .stashed(false)
                 .equipmentId("idLine1")
                 .equipmentName("nameLine1")
                 .seriesResistance(100.0)
@@ -100,6 +102,7 @@ public class LineCreationInBusBreakerTest extends AbstractNetworkModificationTes
     @Test
     public void testCreateLineOptionalParameters3() throws Exception {
         LineCreationInfos lineCreationInfosPermanentLimitOK = LineCreationInfos.builder()
+                .stashed(false)
                 .equipmentId("idLine2")
                 .equipmentName("nameLine2")
                 .seriesResistance(100.0)
@@ -124,6 +127,7 @@ public class LineCreationInBusBreakerTest extends AbstractNetworkModificationTes
     @Test
     public void testCreateLineOptionalParameters4() throws Exception {
         LineCreationInfos lineCreationInfosPermanentLimitOK = LineCreationInfos.builder()
+                .stashed(false)
                 .equipmentId("idLine2")
                 .equipmentName("nameLine2")
                 .seriesResistance(100.0)
@@ -150,6 +154,7 @@ public class LineCreationInBusBreakerTest extends AbstractNetworkModificationTes
     @Test
     public void testCreateLineOptionalParameters5() throws Exception {
         LineCreationInfos lineCreationInfosPermanentLimitNOK = LineCreationInfos.builder()
+                .stashed(false)
                 .equipmentId("idLine2")
                 .equipmentName("nameLine2")
                 .seriesResistance(100.0)
@@ -169,6 +174,7 @@ public class LineCreationInBusBreakerTest extends AbstractNetworkModificationTes
     @Test
     public void testCreateLineOptionalParameters6() throws Exception {
         LineCreationInfos lineCreationInfosOK = LineCreationInfos.builder()
+                .stashed(false)
                 .equipmentId("idLine3")
                 .equipmentName("nameLine3")
                 .seriesResistance(100.0)
@@ -196,6 +202,7 @@ public class LineCreationInBusBreakerTest extends AbstractNetworkModificationTes
         // between voltage level "v1" and busbar section "bus1" and
         //         voltage level "v2" and busbar section "bus2"
         return LineCreationInfos.builder()
+            .stashed(false)
             .equipmentId("idLine1")
             .equipmentName("nameLine1")
             .seriesResistance(100.0)
@@ -216,6 +223,7 @@ public class LineCreationInBusBreakerTest extends AbstractNetworkModificationTes
     @Override
     protected ModificationInfos buildModificationUpdate() {
         return LineCreationInfos.builder()
+            .stashed(false)
             .equipmentId("idLineEdited1")
             .equipmentName("nameLineEdited1")
             .seriesResistance(200.0)

--- a/src/test/java/org/gridsuite/modification/server/modifications/LineCreationInMixedTypologyTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/LineCreationInMixedTypologyTest.java
@@ -37,6 +37,7 @@ public class LineCreationInMixedTypologyTest extends AbstractNetworkModification
         // between voltage level "v1" and busbar section "1.1" type NODE_BREAKER and
         //         voltage level "v2" and busbar section "bus2 type BUS_BREAKER"
         return LineCreationInfos.builder()
+            .stashed(false)
             .equipmentId("idLine1")
             .equipmentName("nameLine1")
             .seriesResistance(100.0)
@@ -61,6 +62,7 @@ public class LineCreationInMixedTypologyTest extends AbstractNetworkModification
     @Override
     protected ModificationInfos buildModificationUpdate() {
         return LineCreationInfos.builder()
+            .stashed(false)
             .equipmentId("idLineEdited1")
             .equipmentName("nameLineEdited1")
             .seriesResistance(200.0)

--- a/src/test/java/org/gridsuite/modification/server/modifications/LineCreationInNodeBreakerTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/LineCreationInNodeBreakerTest.java
@@ -236,6 +236,7 @@ public class LineCreationInNodeBreakerTest extends AbstractNetworkModificationTe
     @Override
     protected ModificationInfos buildModification() {
         return LineCreationInfos.builder()
+                .stashed(false)
                 .equipmentId("idLine")
                 .equipmentName("nameLine")
                 .seriesResistance(100.0)
@@ -260,6 +261,7 @@ public class LineCreationInNodeBreakerTest extends AbstractNetworkModificationTe
     @Override
     protected ModificationInfos buildModificationUpdate() {
         return LineCreationInfos.builder()
+                .stashed(false)
                 .equipmentId("idLineEdited")
                 .equipmentName("nameLineEdited")
                 .seriesResistance(110.0)

--- a/src/test/java/org/gridsuite/modification/server/modifications/LineModificationTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/LineModificationTest.java
@@ -43,7 +43,9 @@ public class LineModificationTest extends AbstractNetworkModificationTest {
 
     @Override
     protected ModificationInfos buildModification() {
-        return LineModificationInfos.builder().equipmentId("line1")
+        return LineModificationInfos.builder()
+                .stashed(false)
+                .equipmentId("line1")
                 .equipmentName(new AttributeModification<>("LineModified", OperationType.SET))
                 .currentLimits1(CurrentLimitsModificationInfos.builder()
                         .temporaryLimits(List.of(CurrentTemporaryLimitModificationInfos.builder()
@@ -67,7 +69,9 @@ public class LineModificationTest extends AbstractNetworkModificationTest {
 
     @Override
     protected ModificationInfos buildModificationUpdate() {
-        return LineModificationInfos.builder().equipmentId("line1")
+        return LineModificationInfos.builder()
+                .stashed(false)
+                .equipmentId("line1")
                 .equipmentName(new AttributeModification<>("LineModified1", OperationType.SET))
                 .seriesReactance(new AttributeModification<>(1.1, OperationType.SET))
                 .seriesResistance(new AttributeModification<>(2.1, OperationType.SET))
@@ -291,6 +295,7 @@ public class LineModificationTest extends AbstractNetworkModificationTest {
                 .endTemporaryLimit()
                 .add();
         LineModificationInfos lineModificationInfos = LineModificationInfos.builder()
+                .stashed(false)
                 .equipmentId("line1")
                 .equipmentName(new AttributeModification<>("LineModified", OperationType.SET))
                 .currentLimits1(CurrentLimitsModificationInfos.builder()
@@ -323,6 +328,7 @@ public class LineModificationTest extends AbstractNetworkModificationTest {
         // Modify name and no modification on temporary limits
         line.setName(null);
         LineModificationInfos lineModificationInfos1 = LineModificationInfos.builder()
+                .stashed(false)
                 .equipmentId("line1")
                 .equipmentName(new AttributeModification<>("ModifiedName", OperationType.SET))
                 .build();

--- a/src/test/java/org/gridsuite/modification/server/modifications/LineSplitWithNewVoltageLevelTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/LineSplitWithNewVoltageLevelTest.java
@@ -55,6 +55,7 @@ public class LineSplitWithNewVoltageLevelTest extends AbstractNetworkModificatio
     @Override
     protected ModificationInfos buildModification() {
         VoltageLevelCreationInfos vl1 = VoltageLevelCreationInfos.builder()
+                .stashed(false)
                 .equipmentId("newVoltageLevel")
                 .equipmentName("NewVoltageLevel")
                 .nominalVoltage(379.3)
@@ -70,6 +71,7 @@ public class LineSplitWithNewVoltageLevelTest extends AbstractNetworkModificatio
                 .build();
 
         return LineSplitWithVoltageLevelInfos.builder()
+            .stashed(false)
             .lineToSplitId("line2")
             .percent(10.0)
             .mayNewVoltageLevelInfos(vl1)
@@ -85,6 +87,7 @@ public class LineSplitWithNewVoltageLevelTest extends AbstractNetworkModificatio
     @Override
     protected ModificationInfos buildModificationUpdate() {
         return LineSplitWithVoltageLevelInfos.builder()
+            .stashed(false)
             .lineToSplitId("line2Edited")
             .percent(20.0)
             .mayNewVoltageLevelInfos(null)

--- a/src/test/java/org/gridsuite/modification/server/modifications/LineSplitWithVoltageLevelTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/LineSplitWithVoltageLevelTest.java
@@ -44,6 +44,7 @@ public class LineSplitWithVoltageLevelTest extends AbstractNetworkModificationTe
     @Override
     protected ModificationInfos buildModification() {
         return LineSplitWithVoltageLevelInfos.builder()
+            .stashed(false)
             .lineToSplitId("line2")
             .percent(10.0)
             .mayNewVoltageLevelInfos(null)
@@ -59,6 +60,7 @@ public class LineSplitWithVoltageLevelTest extends AbstractNetworkModificationTe
     @Override
     protected ModificationInfos buildModificationUpdate() {
         VoltageLevelCreationInfos vl1 = VoltageLevelCreationInfos.builder()
+                .stashed(false)
                 .equipmentId("newVoltageLevel")
                 .equipmentName("NewVoltageLevel")
                 .nominalVoltage(379.3)
@@ -74,6 +76,7 @@ public class LineSplitWithVoltageLevelTest extends AbstractNetworkModificationTe
                 .build();
 
         return LineSplitWithVoltageLevelInfos.builder()
+            .stashed(false)
             .lineToSplitId("line2Edited")
             .percent(20.0)
             .mayNewVoltageLevelInfos(vl1)

--- a/src/test/java/org/gridsuite/modification/server/modifications/LinesAttachToSplitLinesTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/LinesAttachToSplitLinesTest.java
@@ -42,6 +42,7 @@ public class LinesAttachToSplitLinesTest extends AbstractNetworkModificationTest
     @Override
     protected ModificationInfos buildModification() {
         return LinesAttachToSplitLinesInfos.builder()
+                .stashed(false)
                 .lineToAttachTo1Id("l1")
                 .lineToAttachTo2Id("l2")
                 .attachedLineId("l3")
@@ -57,6 +58,7 @@ public class LinesAttachToSplitLinesTest extends AbstractNetworkModificationTest
     @Override
     protected ModificationInfos buildModificationUpdate() {
         return LinesAttachToSplitLinesInfos.builder()
+                .stashed(false)
                 .lineToAttachTo1Id("newline1")
                 .lineToAttachTo2Id("newline2")
                 .attachedLineId("newline3")

--- a/src/test/java/org/gridsuite/modification/server/modifications/LoadCreationInBusBreakerTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/LoadCreationInBusBreakerTest.java
@@ -34,6 +34,7 @@ public class LoadCreationInBusBreakerTest extends AbstractNetworkModificationTes
     @Override
     protected ModificationInfos buildModification() {
         return LoadCreationInfos.builder()
+            .stashed(false)
             .equipmentId("idLoad1")
             .equipmentName("nameLoad1")
             .voltageLevelId("v1")
@@ -49,6 +50,7 @@ public class LoadCreationInBusBreakerTest extends AbstractNetworkModificationTes
     @Override
     protected ModificationInfos buildModificationUpdate() {
         return LoadCreationInfos.builder()
+            .stashed(false)
             .equipmentId("idLoadEdited1")
             .equipmentName("nameLoadEdited1")
             .voltageLevelId("v1Edited")

--- a/src/test/java/org/gridsuite/modification/server/modifications/LoadCreationInNodeBreakerTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/LoadCreationInNodeBreakerTest.java
@@ -103,6 +103,7 @@ public class LoadCreationInNodeBreakerTest extends AbstractNetworkModificationTe
     @Override
     protected ModificationInfos buildModification() {
         return LoadCreationInfos.builder()
+            .stashed(false)
             .equipmentId("idLoad1")
             .equipmentName("nameLoad1")
             .voltageLevelId("v2")
@@ -118,6 +119,7 @@ public class LoadCreationInNodeBreakerTest extends AbstractNetworkModificationTe
     @Override
     protected ModificationInfos buildModificationUpdate() {
         return LoadCreationInfos.builder()
+            .stashed(false)
             .equipmentId("idLoad1Edited")
             .equipmentName("nameLoad1Edited")
             .voltageLevelId("v2Edited")

--- a/src/test/java/org/gridsuite/modification/server/modifications/LoadModificationTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/LoadModificationTest.java
@@ -41,6 +41,7 @@ public class LoadModificationTest extends AbstractNetworkModificationTest {
     @Override
     protected ModificationInfos buildModification() {
         return LoadModificationInfos.builder()
+            .stashed(false)
             .equipmentId("v1load")
             .equipmentName(new AttributeModification<>("nameLoad1", OperationType.SET))
             .loadType(new AttributeModification<>(LoadType.FICTITIOUS, OperationType.SET))
@@ -53,6 +54,7 @@ public class LoadModificationTest extends AbstractNetworkModificationTest {
     protected ModificationInfos buildModificationUpdate() {
         return LoadModificationInfos.builder()
             .equipmentId("v1loadEdited")
+            .stashed(false)
             .equipmentName(new AttributeModification<>("nameLoadEdited1", OperationType.SET))
             .loadType(new AttributeModification<>(LoadType.AUXILIARY, OperationType.SET))
             .activePower(new AttributeModification<>(300.0, OperationType.SET))
@@ -84,6 +86,7 @@ public class LoadModificationTest extends AbstractNetworkModificationTest {
     public void testCreateWithErrors() throws Exception {
         // Unset an attribute that should not be null
         LoadModificationInfos loadModificationInfos = LoadModificationInfos.builder()
+                .stashed(false)
                 .equipmentId("v1load")
                 .loadType(new AttributeModification<>(null, OperationType.UNSET))
                 .build();

--- a/src/test/java/org/gridsuite/modification/server/modifications/LoadScalingTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/LoadScalingTest.java
@@ -178,6 +178,7 @@ public class LoadScalingTest extends AbstractNetworkModificationTest {
             .build();
 
         ModificationInfos modificationToCreate = LoadScalingInfos.builder()
+            .stashed(false)
             .uuid(LOAD_SCALING_ID)
             .date(ZonedDateTime.now().truncatedTo(ChronoUnit.MICROS))
             .variationType(VariationType.DELTA_P)
@@ -346,6 +347,7 @@ public class LoadScalingTest extends AbstractNetworkModificationTest {
             .build();
 
         return LoadScalingInfos.builder()
+            .stashed(false)
             .date(ZonedDateTime.now().truncatedTo(ChronoUnit.MICROS))
             .variationType(VariationType.DELTA_P)
             .variations(List.of(variation1, variation2, variation3, variation4, variation5))
@@ -367,6 +369,7 @@ public class LoadScalingTest extends AbstractNetworkModificationTest {
             .build();
 
         return LoadScalingInfos.builder()
+            .stashed(false)
             .uuid(LOAD_SCALING_ID)
             .date(ZonedDateTime.now().truncatedTo(ChronoUnit.MICROS))
             .variationType(VariationType.TARGET_P)

--- a/src/test/java/org/gridsuite/modification/server/modifications/ShuntCompensatorCreationInBusBreakerTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/ShuntCompensatorCreationInBusBreakerTest.java
@@ -54,6 +54,7 @@ public class ShuntCompensatorCreationInBusBreakerTest extends AbstractNetworkMod
     @Override
     protected ModificationInfos buildModification() {
         return ShuntCompensatorCreationInfos.builder()
+            .stashed(false)
             .date(ZonedDateTime.now().truncatedTo(ChronoUnit.MICROS))
             .equipmentId("shuntOneId")
             .equipmentName("hopOne")
@@ -70,6 +71,7 @@ public class ShuntCompensatorCreationInBusBreakerTest extends AbstractNetworkMod
     @Override
     protected ModificationInfos buildModificationUpdate() {
         return ShuntCompensatorCreationInfos.builder()
+                .stashed(false)
                 .date(ZonedDateTime.now().truncatedTo(ChronoUnit.MICROS))
                 .equipmentId("shuntOneIdEdited")
                 .equipmentName("hopEdited")

--- a/src/test/java/org/gridsuite/modification/server/modifications/ShuntCompensatorCreationInNodeBreakerTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/ShuntCompensatorCreationInNodeBreakerTest.java
@@ -46,6 +46,7 @@ public class ShuntCompensatorCreationInNodeBreakerTest extends AbstractNetworkMo
     @Override
     protected ModificationInfos buildModification() {
         return ShuntCompensatorCreationInfos.builder()
+                .stashed(false)
                 .date(ZonedDateTime.now().truncatedTo(ChronoUnit.MICROS))
                 .equipmentId("shuntOneId")
                 .equipmentName("hop")
@@ -63,6 +64,7 @@ public class ShuntCompensatorCreationInNodeBreakerTest extends AbstractNetworkMo
     @Override
     protected ModificationInfos buildModificationUpdate() {
         return ShuntCompensatorCreationInfos.builder()
+                .stashed(false)
                 .date(ZonedDateTime.now().truncatedTo(ChronoUnit.MICROS))
                 .equipmentId("shuntOneIdEdited")
                 .equipmentName("hopEdited")

--- a/src/test/java/org/gridsuite/modification/server/modifications/ShuntCompensatorModificationTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/ShuntCompensatorModificationTest.java
@@ -46,6 +46,7 @@ public class ShuntCompensatorModificationTest extends AbstractNetworkModificatio
     @Test
     public void testEquipmentWithWrongId() {
         var shuntCompensator = ShuntCompensatorModificationInfos.builder()
+                .stashed(false)
                 .equipmentId("wrong id")
                 .build();
 
@@ -60,6 +61,7 @@ public class ShuntCompensatorModificationTest extends AbstractNetworkModificatio
     @Test
     public void testWrongVoltageLevelId() {
         var shuntCompensator = ShuntCompensatorModificationInfos.builder()
+                .stashed(false)
                 .equipmentId("v5shunt")
                 .voltageLevelId("wrongVLId")
                 .build();
@@ -77,6 +79,7 @@ public class ShuntCompensatorModificationTest extends AbstractNetworkModificatio
         var shuntCompensator = getNetwork().getShuntCompensator("v5shunt");
 
         ShuntCompensatorModificationInfos modificationInfos = ShuntCompensatorModificationInfos.builder()
+                .stashed(false)
                 .equipmentId("v5shunt")
                 .voltageLevelId("v5")
                 .shuntCompensatorType(new AttributeModification<>(ShuntCompensatorType.REACTOR, OperationType.SET))
@@ -101,6 +104,7 @@ public class ShuntCompensatorModificationTest extends AbstractNetworkModificatio
 
         assertEquals(1.0, model.getBPerSection(), 0);
         ShuntCompensatorModificationInfos modificationInfos = ShuntCompensatorModificationInfos.builder()
+                .stashed(false)
                 .equipmentId("v7shunt")
                 .voltageLevelId("v5")
                 .shuntCompensatorType(new AttributeModification<>(ShuntCompensatorType.REACTOR, OperationType.SET))
@@ -124,6 +128,7 @@ public class ShuntCompensatorModificationTest extends AbstractNetworkModificatio
 
         assertEquals(1.0, model.getBPerSection(), 0);
         ShuntCompensatorModificationInfos modificationInfos = ShuntCompensatorModificationInfos.builder()
+                .stashed(false)
                 .equipmentId("v7shunt")
                 .voltageLevelId("v5")
                 .susceptancePerSection(AttributeModification.toAttributeModification(3.0, OperationType.SET))
@@ -145,6 +150,7 @@ public class ShuntCompensatorModificationTest extends AbstractNetworkModificatio
         createShuntCompensator(v6, "v8shunt", "v8shunt", 6, 225., 10, true, 1, 1, 2, 1, "feeder_v8shunt", 50, ConnectablePosition.Direction.BOTTOM);
 
         ShuntCompensatorModificationInfos modificationInfos1 = ShuntCompensatorModificationInfos.builder()
+                        .stashed(false)
                         .equipmentId("v7shunt")
                         .voltageLevelId("v5")
                         .qAtNominalV(new AttributeModification<>(30.5, OperationType.SET))
@@ -152,6 +158,7 @@ public class ShuntCompensatorModificationTest extends AbstractNetworkModificatio
                         .build();
 
         ShuntCompensatorModificationInfos modificationInfos2 = ShuntCompensatorModificationInfos.builder()
+                .stashed(false)
                 .equipmentId("v8shunt")
                 .voltageLevelId("v6")
                 .qAtNominalV(new AttributeModification<>(30.5, OperationType.SET))
@@ -181,6 +188,7 @@ public class ShuntCompensatorModificationTest extends AbstractNetworkModificatio
         createShuntCompensator(v2, "v7shunt", "v7shunt", 15, 225., 10, true, 1, 1, 2, 1, "feeder_v7shunt", 40, ConnectablePosition.Direction.BOTTOM);
 
         return ShuntCompensatorModificationInfos.builder()
+                .stashed(false)
                 .equipmentId("v7shunt")
                 .shuntCompensatorType(new AttributeModification<>(ShuntCompensatorType.CAPACITOR, OperationType.SET))
                 .qAtNominalV(new AttributeModification<>(15.0, OperationType.SET))
@@ -192,6 +200,7 @@ public class ShuntCompensatorModificationTest extends AbstractNetworkModificatio
     @Override
     protected ModificationInfos buildModificationUpdate() {
         return ShuntCompensatorModificationInfos.builder()
+                .stashed(false)
                 .equipmentId("v2shunt")
                 .voltageLevelId("v2")
                 .susceptancePerSection(new AttributeModification<>(0.5, OperationType.SET))

--- a/src/test/java/org/gridsuite/modification/server/modifications/SubstationCreationTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/SubstationCreationTest.java
@@ -39,6 +39,7 @@ public class SubstationCreationTest extends AbstractNetworkModificationTest {
     @Override
     protected ModificationInfos buildModification() {
         return SubstationCreationInfos.builder()
+                .stashed(false)
                 .equipmentId("SubstationId")
                 .equipmentName("SubstationName")
                 .substationCountry(Country.AF)
@@ -49,6 +50,7 @@ public class SubstationCreationTest extends AbstractNetworkModificationTest {
     @Override
     protected ModificationInfos buildModificationUpdate() {
         return SubstationCreationInfos.builder()
+                .stashed(false)
                 .equipmentId("SubstationIdEdited")
                 .equipmentName("SubstationNameEdited")
                 .substationCountry(Country.CI)

--- a/src/test/java/org/gridsuite/modification/server/modifications/SubstationDeletionTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/SubstationDeletionTest.java
@@ -31,6 +31,7 @@ public class SubstationDeletionTest extends AbstractNetworkModificationTest {
     @Override
     protected ModificationInfos buildModification() {
         return EquipmentDeletionInfos.builder()
+                .stashed(false)
                 .equipmentType("SUBSTATION")
                 .equipmentId("s1")
                 .build();
@@ -39,6 +40,7 @@ public class SubstationDeletionTest extends AbstractNetworkModificationTest {
     @Override
     protected ModificationInfos buildModificationUpdate() {
         return EquipmentDeletionInfos.builder()
+                .stashed(false)
                 .equipmentType("LINE")
                 .equipmentId("v2")
                 .build();

--- a/src/test/java/org/gridsuite/modification/server/modifications/SubstationModificationTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/SubstationModificationTest.java
@@ -43,6 +43,7 @@ public class SubstationModificationTest extends AbstractNetworkModificationTest 
     @Override
     protected ModificationInfos buildModification() {
         return SubstationModificationInfos.builder()
+            .stashed(false)
             .equipmentId("s3")
             .equipmentName(new AttributeModification<>("newName", OperationType.SET))
             .substationCountry(new AttributeModification<>(Country.BQ, OperationType.SET))
@@ -57,6 +58,7 @@ public class SubstationModificationTest extends AbstractNetworkModificationTest 
     protected ModificationInfos buildModificationUpdate() {
         return SubstationModificationInfos.builder()
             .equipmentId("s3Edited")
+            .stashed(false)
             .equipmentName(new AttributeModification<>("newNameEdited1", OperationType.SET))
             .substationCountry(new AttributeModification<>(Country.JP, OperationType.SET))
             .properties(null)

--- a/src/test/java/org/gridsuite/modification/server/modifications/TwoWindingsTransformerCreationBusBreakerTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/TwoWindingsTransformerCreationBusBreakerTest.java
@@ -45,6 +45,7 @@ public class TwoWindingsTransformerCreationBusBreakerTest extends AbstractNetwor
     @Override
     protected ModificationInfos buildModification() {
         return TwoWindingsTransformerCreationInfos.builder()
+                .stashed(false)
                 .equipmentId("new2wt")
                 .equipmentName("new2wt")
                 .seriesResistance(1.)
@@ -150,6 +151,7 @@ public class TwoWindingsTransformerCreationBusBreakerTest extends AbstractNetwor
     @Override
     protected ModificationInfos buildModificationUpdate() {
         return TwoWindingsTransformerCreationInfos.builder()
+                .stashed(false)
                 .equipmentId("new2wtUpdate")
                 .equipmentName("new2wtUpdate")
                 .seriesResistance(2.3)
@@ -308,6 +310,7 @@ public class TwoWindingsTransformerCreationBusBreakerTest extends AbstractNetwor
                 .build();
         // create new 2wt in voltage level with bus/breaker topology
         TwoWindingsTransformerCreationInfos twoWindingsTransformerCreationInfos = TwoWindingsTransformerCreationInfos.builder()
+                .stashed(false)
                 .equipmentId("id2wt1")
                 .equipmentName("2wtName")
                 .voltageLevelId1("v1")
@@ -325,6 +328,7 @@ public class TwoWindingsTransformerCreationBusBreakerTest extends AbstractNetwor
                 .build();
         testCreateTwoWindingsTransformerInBusBreaker(twoWindingsTransformerCreationInfos, 1);
         TwoWindingsTransformerCreationInfos twoWindingsTransformerCreationInfos2 = TwoWindingsTransformerCreationInfos.builder()
+                .stashed(false)
                 .equipmentId("id2wt1WithRatioTapChanger2")
                 .equipmentName("2wtName")
                 .voltageLevelId1("v1")
@@ -360,6 +364,7 @@ public class TwoWindingsTransformerCreationBusBreakerTest extends AbstractNetwor
                 .steps(getTapChangerSteps())
                 .build();
         TwoWindingsTransformerCreationInfos twoWindingsTransformerCreationInfos = TwoWindingsTransformerCreationInfos.builder()
+                .stashed(false)
                 .equipmentId("id2wt1WithPhaseTapChanger")
                 .equipmentName("2wtName")
                 .voltageLevelId1("v1")

--- a/src/test/java/org/gridsuite/modification/server/modifications/TwoWindingsTransformerCreationMixedBreakerTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/TwoWindingsTransformerCreationMixedBreakerTest.java
@@ -40,6 +40,7 @@ public class TwoWindingsTransformerCreationMixedBreakerTest extends AbstractNetw
     @Override
     protected ModificationInfos buildModification() {
         return TwoWindingsTransformerCreationInfos.builder()
+                .stashed(false)
                 .equipmentId("id2wt1")
                 .equipmentName("2wtName")
                 .voltageLevelId1("v1")
@@ -143,6 +144,7 @@ public class TwoWindingsTransformerCreationMixedBreakerTest extends AbstractNetw
     @Override
     protected ModificationInfos buildModificationUpdate() {
         return TwoWindingsTransformerCreationInfos.builder()
+                .stashed(false)
                 .equipmentId("new2wtUpdate")
                 .equipmentName("new2wtUpdate")
                 .seriesResistance(2.3)

--- a/src/test/java/org/gridsuite/modification/server/modifications/TwoWindingsTransformerCreationNodeBreakerTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/TwoWindingsTransformerCreationNodeBreakerTest.java
@@ -45,6 +45,7 @@ public class TwoWindingsTransformerCreationNodeBreakerTest extends AbstractNetwo
     @Override
     protected ModificationInfos buildModification() {
         return TwoWindingsTransformerCreationInfos.builder()
+                .stashed(false)
                 .equipmentId("new2wt")
                 .equipmentName("new2wt")
                 .seriesResistance(1.)
@@ -150,6 +151,7 @@ public class TwoWindingsTransformerCreationNodeBreakerTest extends AbstractNetwo
     @Override
     protected ModificationInfos buildModificationUpdate() {
         return TwoWindingsTransformerCreationInfos.builder()
+                .stashed(false)
                 .equipmentId("new2wtUpdate")
                 .equipmentName("new2wtUpdate")
                 .seriesResistance(10.)

--- a/src/test/java/org/gridsuite/modification/server/modifications/TwoWindingsTransformerModificationTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/TwoWindingsTransformerModificationTest.java
@@ -45,7 +45,7 @@ public class TwoWindingsTransformerModificationTest extends AbstractNetworkModif
 
     @Override
     protected ModificationInfos buildModification() {
-        return TwoWindingsTransformerModificationInfos.builder().equipmentId("trf1")
+        return TwoWindingsTransformerModificationInfos.builder().stashed(false).equipmentId("trf1")
                 .equipmentName(new AttributeModification<>("2wt modified name", OperationType.SET))
                 .seriesResistance(new AttributeModification<>(1., OperationType.SET))
                 .seriesReactance(new AttributeModification<>(2., OperationType.SET))
@@ -135,7 +135,9 @@ public class TwoWindingsTransformerModificationTest extends AbstractNetworkModif
 
     @Override
     protected ModificationInfos buildModificationUpdate() {
-        return TwoWindingsTransformerModificationInfos.builder().equipmentId("trf1Edited")
+        return TwoWindingsTransformerModificationInfos.builder()
+                .stashed(false)
+                .equipmentId("trf1Edited")
                 .equipmentName(new AttributeModification<>("2wt modified name again", OperationType.SET))
                 .seriesResistance(new AttributeModification<>(1.1, OperationType.SET))
                 .seriesReactance(new AttributeModification<>(2.1, OperationType.SET))
@@ -288,6 +290,7 @@ public class TwoWindingsTransformerModificationTest extends AbstractNetworkModif
     @Test
     public void testRatioTapChangerModification() throws Exception {
         TwoWindingsTransformerModificationInfos twoWindingsTransformerModificationInfos = TwoWindingsTransformerModificationInfos.builder()
+                .stashed(false)
                 .equipmentId("trf1")
                 .phaseTapChanger(PhaseTapChangerModificationInfos.builder()
                         .build())
@@ -409,6 +412,7 @@ public class TwoWindingsTransformerModificationTest extends AbstractNetworkModif
     @Test
     public void testPhaseTapChangerModification() throws Exception {
         TwoWindingsTransformerModificationInfos twoWindingsTransformerModificationInfos = TwoWindingsTransformerModificationInfos.builder()
+                .stashed(false)
                 .equipmentId("trf2")
                 .ratioTapChanger(RatioTapChangerModificationInfos.builder()
                         .build())

--- a/src/test/java/org/gridsuite/modification/server/modifications/VoltageInitModificationTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/VoltageInitModificationTest.java
@@ -94,6 +94,7 @@ public class VoltageInitModificationTest extends AbstractNetworkModificationTest
     @Override
     protected ModificationInfos buildModification() {
         return VoltageInitModificationInfos.builder()
+            .stashed(false)
             .generators(List.of(
                 VoltageInitGeneratorModificationInfos.builder()
                     .generatorId("idGenerator")
@@ -188,6 +189,7 @@ public class VoltageInitModificationTest extends AbstractNetworkModificationTest
     @Override
     protected ModificationInfos buildModificationUpdate() {
         return VoltageInitModificationInfos.builder()
+            .stashed(false)
             .generators(List.of(
                 VoltageInitGeneratorModificationInfos.builder()
                     .generatorId("idGenerator")
@@ -249,6 +251,7 @@ public class VoltageInitModificationTest extends AbstractNetworkModificationTest
         getNetwork().getShuntCompensator(shuntCompensatorId).setSectionCount(currentSectionCount);
 
         VoltageInitModificationInfos modification = VoltageInitModificationInfos.builder()
+            .stashed(false)
             .generators(List.of())
             .transformers(List.of())
             .staticVarCompensators(List.of())

--- a/src/test/java/org/gridsuite/modification/server/modifications/VoltageLevelCreationTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/VoltageLevelCreationTest.java
@@ -51,6 +51,7 @@ public class VoltageLevelCreationTest extends AbstractNetworkModificationTest {
     @Override
     protected ModificationInfos buildModificationUpdate() {
         return VoltageLevelCreationInfos.builder()
+                .stashed(false)
                 .equipmentId("VoltageLevelIdEdited")
                 .equipmentName("VoltageLevelEdited")
                 .substationId("s2")

--- a/src/test/java/org/gridsuite/modification/server/modifications/VoltageLevelDeletionTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/VoltageLevelDeletionTest.java
@@ -31,6 +31,7 @@ public class VoltageLevelDeletionTest extends AbstractNetworkModificationTest {
     @Override
     protected ModificationInfos buildModification() {
         return EquipmentDeletionInfos.builder()
+                .stashed(false)
                 .equipmentType("VOLTAGE_LEVEL")
                 .equipmentId("v1")
                 .build();
@@ -39,6 +40,7 @@ public class VoltageLevelDeletionTest extends AbstractNetworkModificationTest {
     @Override
     protected ModificationInfos buildModificationUpdate() {
         return EquipmentDeletionInfos.builder()
+                .stashed(false)
                 .equipmentType("LINE")
                 .equipmentId("v2")
                 .build();

--- a/src/test/java/org/gridsuite/modification/server/modifications/VoltageLevelModificationTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/VoltageLevelModificationTest.java
@@ -42,6 +42,7 @@ public class VoltageLevelModificationTest extends AbstractNetworkModificationTes
     @Override
     protected ModificationInfos buildModification() {
         return VoltageLevelModificationInfos.builder()
+                .stashed(false)
                 .equipmentId("v1")
                 .equipmentName(new AttributeModification<>("test 1", OperationType.SET))
                 .nominalVoltage(new AttributeModification<>(420D, OperationType.SET))
@@ -55,6 +56,7 @@ public class VoltageLevelModificationTest extends AbstractNetworkModificationTes
     @Override
     protected ModificationInfos buildModificationUpdate() {
         return VoltageLevelModificationInfos.builder()
+                .stashed(false)
                 .equipmentId("v1Edited")
                 .equipmentName(new AttributeModification<>("test 2", OperationType.SET))
                 .nominalVoltage(new AttributeModification<>(450D, OperationType.SET))
@@ -96,6 +98,7 @@ public class VoltageLevelModificationTest extends AbstractNetworkModificationTes
         applyModification(infos);
 
         VoltageLevelModificationInfos updatedInfos = VoltageLevelModificationInfos.builder()
+                .stashed(false)
                 .equipmentId("v1")
                 .ipMax(new AttributeModification<>(0.9, OperationType.SET))
                 .build();

--- a/src/test/java/org/gridsuite/modification/server/modifications/VscCreationTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/VscCreationTest.java
@@ -55,6 +55,7 @@ public class VscCreationTest extends AbstractNetworkModificationTest {
     @Override
     protected ModificationInfos buildModification() {
         return VscCreationInfos.builder()
+                .stashed(false)
                 .equipmentId("vsc1")
                 .equipmentName("vsc1Name")
                 .dcNominalVoltage(39.)
@@ -124,6 +125,7 @@ public class VscCreationTest extends AbstractNetworkModificationTest {
     @Override
     protected ModificationInfos buildModificationUpdate() {
         return VscCreationInfos.builder()
+                .stashed(false)
                 .equipmentId("vsc1Edited")
                 .equipmentName("vsc2Name")
                 .dcNominalVoltage(53.)

--- a/src/test/java/org/gridsuite/modification/server/utils/ModificationCreation.java
+++ b/src/test/java/org/gridsuite/modification/server/utils/ModificationCreation.java
@@ -23,6 +23,7 @@ public final class ModificationCreation {
 
     public static VoltageLevelCreationInfos getCreationVoltageLevel(String substationId, String voltageLevelId, String voltageLevelName) {
         return VoltageLevelCreationInfos.builder()
+            .stashed(false)
             .equipmentId(voltageLevelId)
             .equipmentName(voltageLevelName)
             .substationId(substationId)
@@ -39,6 +40,7 @@ public final class ModificationCreation {
 
     public static BatteryCreationInfos getCreationBattery(String vlId, String batteryId, String batteryName, String busOrBusbarSectionId) {
         return BatteryCreationInfos.builder()
+                .stashed(false)
                 .equipmentId(batteryId)
                 .equipmentName(batteryName)
                 .voltageLevelId(vlId)
@@ -62,6 +64,7 @@ public final class ModificationCreation {
     public static GeneratorCreationInfos getCreationGenerator(String vlId, String generatorId, String generatorName, String busOrBusbarSectionId,
                                                               String regulatingTerminalId, String regulatingTerminalType, String regulatingTerminalVlId) {
         return GeneratorCreationInfos.builder()
+            .stashed(false)
             .equipmentId(generatorId)
             .equipmentName(generatorName)
             .voltageLevelId(vlId)


### PR DESCRIPTION
Problems:
toModificationInfos() implemented in each modification, does not set the attribute "stashed"

Fix:
set this attribute in the builder of each modification