### PR TITLE
Fix `ModificationInfos` exceptions

### DIFF
--- a/src/main/java/org/gridsuite/modification/server/dto/ModificationInfos.java
+++ b/src/main/java/org/gridsuite/modification/server/dto/ModificationInfos.java
@@ -23,6 +23,7 @@ import org.gridsuite.modification.server.NetworkModificationException;
 import org.gridsuite.modification.server.dto.annotation.ModificationErrorTypeName;
 import org.gridsuite.modification.server.entities.ModificationEntity;
 import org.gridsuite.modification.server.modifications.AbstractModification;
+import org.springframework.core.annotation.AnnotationUtils;
 
 import java.time.ZonedDateTime;
 import java.util.UUID;
@@ -101,12 +102,22 @@ public class ModificationInfos {
 
     @JsonIgnore
     public final NetworkModificationException.Type getErrorType() {
-        return NetworkModificationException.Type.valueOf(this.getClass().getAnnotation(ModificationErrorTypeName.class).value());
+        final ModificationErrorTypeName annotation = AnnotationUtils.findAnnotation(this.getClass(), ModificationErrorTypeName.class);
+        if (annotation != null) {
+            return NetworkModificationException.Type.valueOf(annotation.value());
+        } else {
+            return null;
+        }
     }
 
     @JsonIgnore
     public final ModificationType getType() {
-        return ModificationType.valueOf(this.getClass().getAnnotation(JsonTypeName.class).value());
+        final JsonTypeName annotation = AnnotationUtils.findAnnotation(this.getClass(), JsonTypeName.class);
+        if (annotation != null) {
+            return ModificationType.valueOf(annotation.value());
+        } else {
+            return null;
+        }
     }
 
     @JsonIgnore

--- a/src/test/java/org/gridsuite/modification/server/dto/ModificationInfosTest.java
+++ b/src/test/java/org/gridsuite/modification/server/dto/ModificationInfosTest.java
@@ -1,0 +1,163 @@
+package org.gridsuite.modification.server.dto;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.powsybl.commons.reporter.ReporterModel;
+import org.assertj.core.api.Condition;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.WithAssertions;
+import org.assertj.core.api.WithAssumptions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.gridsuite.modification.server.ModificationType;
+import org.gridsuite.modification.server.NetworkModificationApplication;
+import org.gridsuite.modification.server.NetworkModificationException;
+import org.gridsuite.modification.server.NetworkModificationException.Type;
+import org.gridsuite.modification.server.dto.annotation.ModificationErrorTypeName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.SimpleBeanDefinitionRegistry;
+import org.springframework.context.annotation.ClassPathBeanDefinitionScanner;
+import org.springframework.core.type.filter.AssignableTypeFilter;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+
+@DisplayNameGeneration(DisplayNameGenerator.Simple.class)
+@ExtendWith(SoftAssertionsExtension.class)
+@Tag("UnitTest")
+class ModificationInfosTest implements WithAssertions, WithAssumptions {
+    @Test
+    void testGetTypeNullWhenNoAnnotation() {
+        final ModificationInfos modification = new ModificationInfos() { };
+        assertThat(modification.getType()).as("modification type").isNull();
+    }
+
+    @Test
+    void testGetTypeValueWhenAnnotation() {
+        final ModificationInfos modification = new ModificationWithAnnotations();
+        assertThat(modification.getType()).as("modification type").isEqualTo(ModificationType.VSC_CREATION);
+    }
+
+    @Test
+    void testGetErrorTypeNullWhenNoAnnotation() {
+        final ModificationInfos modification = new ModificationInfos() { };
+        assertThat(modification.getErrorType()).as("modification error type").isNull();
+    }
+
+    @Test
+    void testGetErrorTypeValueWhenAnnotation() {
+        final ModificationInfos modification = new ModificationWithAnnotations();
+        assertThat(modification.getErrorType()).as("modification error type").isEqualTo(Type.CREATE_VSC_ERROR);
+    }
+
+    @ModificationErrorTypeName("CREATE_VSC_ERROR")
+    @JsonTypeName("VSC_CREATION")
+    private static class ModificationWithAnnotations extends ModificationInfos {
+        // ...
+    }
+
+    private static List<Arguments> provideModificationInfosImplementationsWithClasses() throws ClassNotFoundException {
+        final BeanDefinitionRegistry bdr = new SimpleBeanDefinitionRegistry();
+        final ClassPathBeanDefinitionScanner scanner = new ClassPathBeanDefinitionScanner(bdr);
+        scanner.resetFilters(false); //remove the default Spring filters that would include all classes with @Component, @Service, and some other annotations
+        scanner.setIncludeAnnotationConfig(false); //filter Spring own classes out
+        scanner.addIncludeFilter(new AssignableTypeFilter(ModificationInfos.class)); //we search all children classes
+        scanner.scan(NetworkModificationApplication.class.getPackageName()); //we scan the application package
+
+        final List<Arguments> arguments = new ArrayList<>(bdr.getBeanDefinitionCount());
+        for (final String beanName : bdr.getBeanDefinitionNames()) {
+            final String clazzName = bdr.getBeanDefinition(beanName).getBeanClassName();
+            if (ModificationInfos.class.getCanonicalName().equals(clazzName) ||
+                    ModificationWithAnnotations.class.getName().equals(clazzName)) {
+                continue; //skip parent, we want only children and no test class
+            }
+            final Class<? extends ModificationInfos> clazz = (Class<? extends ModificationInfos>) Class.forName(clazzName);
+            arguments.add(Arguments.of(clazz.getSimpleName(), clazz));
+        }
+        return arguments;
+    }
+
+    private static List<Arguments> provideModificationInfosImplementationsWithInstances()
+            throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
+        final List<Arguments> srcArgs = provideModificationInfosImplementationsWithClasses();
+
+        final List<Arguments> newArgs = new ArrayList<>(srcArgs.size());
+        for (final Arguments argumentInput : srcArgs) {
+            Object[] arguments = argumentInput.get();
+            final Class<? extends ModificationInfos> clazz = (Class<? extends ModificationInfos>) arguments[1];
+            final ModificationInfos instance = clazz.getDeclaredConstructor().newInstance(); //use default (empty) constructor
+            arguments[1] = instance;
+            newArgs.add(Arguments.of(arguments));
+        }
+        return newArgs;
+    }
+
+    @ParameterizedTest(name = "for class {0}")
+    @MethodSource("provideModificationInfosImplementationsWithInstances")
+    void checkMethodsUnsupportedOperationOverrides(final String name, final ModificationInfos instance, final SoftAssertions softly) throws UnsupportedOperationException {
+        try {
+            softly.assertThat(instance.toEntity()).isNotNull();
+        } catch (final NullPointerException rEx) {
+            //Assumptions.abort("conversion append on uninitialized fields");
+        } catch (final NetworkModificationException ex) {
+            //Assumptions.abort("internal check on uninitialized field prevent verification");
+        }
+        softly.assertThat(instance.toModification()).isNotNull();
+        try {
+            softly.assertThat(instance.createSubReporter(new ReporterModel("test", "test reporter"))).isNotNull();
+        } catch (final NullPointerException rEx) {
+            //Assumptions.abort("sub reporter template need uninitialized value");
+        }
+    }
+
+    @Test
+    void isAllSubTypesDeclared() throws Exception {
+        final Class[] implementations = provideModificationInfosImplementationsWithClasses().stream()
+                .map(args -> (Class<?>) args.get()[1])
+                .toArray(Class[]::new);
+        assertThat(ModificationInfos.class.getAnnotation(JsonSubTypes.class).value())
+                .as("ModificationInfos Jackson SubTypes declared")
+                .isNotEmpty()
+                .extracting(JsonSubTypes.Type::value)
+                .doesNotHaveDuplicates()
+                .containsExactlyInAnyOrder(Arrays.stream(implementations).filter(Predicate.not(_class -> Arrays.asList(
+                        ScalingInfos.class, BasicEquipmentModificationInfos.class, BranchCreationInfos.class,
+                        EquipmentModificationInfos.class, InjectionModificationInfos.class, InjectionCreationInfos.class,
+                        EquipmentCreationInfos.class, BranchModificationInfos.class
+                    ).contains(_class))).toArray(Class[]::new)); //TODO check if theses classes are forget intentionally or not
+    }
+
+    /*
+     * because else error in ModificationInfos.getType()
+     */
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("provideModificationInfosImplementationsWithClasses")
+    void isAllJsonNamesValid(final String name, final Class<? extends ModificationInfos> clazz) throws IllegalArgumentException {
+        assumeThat(clazz).as("implementations class").hasAnnotation(JsonTypeName.class); //TODO check if classes without @JsonTypeName wanted or forgotten
+        final Condition<String> isInModificationType = new Condition<>(s -> ModificationType.valueOf(s) != null, "is a ModificationType value");
+        assertThat(clazz.getAnnotation(JsonTypeName.class).value()).as("implementations class Json name type")
+                .satisfies(isInModificationType);
+    }
+
+    /*
+     * because else error in ModificationInfos.getErrorType()
+     */
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("provideModificationInfosImplementationsWithClasses")
+    void isAllErrorTypesValid(final String name, final Class<? extends ModificationInfos> clazz) throws IllegalArgumentException {
+        assumeThat(clazz).as("implementations class").hasAnnotation(ModificationErrorTypeName.class); //TODO check if classes without @ModificationErrorTypeName wanted or forgotten
+        final Condition<String> isInModificationType = new Condition<>(s -> Type.valueOf(s) != null, "is a NetworkModificationException Type value");
+        assertThat(clazz.getAnnotation(ModificationErrorTypeName.class).value()).as("implementations class Json name type")
+                .satisfies(isInModificationType);
+    }
+}

--- a/src/test/java/org/gridsuite/modification/server/dto/ModificationInfosTest.java
+++ b/src/test/java/org/gridsuite/modification/server/dto/ModificationInfosTest.java
@@ -133,28 +133,47 @@ class ModificationInfosTest implements WithAssertions, WithAssumptions {
                 .isInstanceOf(UnsupportedOperationException.class);*/
     }
 
+    @DisplayName("Check toEntity() is override")
     @ParameterizedTest(name = "for class {0}")
     @MethodSource("provideTerminalImplementationsWithInstances")
-    void checkMethodsUnsupportedOperationOverrides(final String name, final ModificationInfos instance, final SoftAssertions softly) throws UnsupportedOperationException {
+    void checkMethodsUnsupportedOperationOverrideToEntity(final String name, final ModificationInfos instance,
+                                                          final SoftAssertions softly) throws UnsupportedOperationException {
         try {
             softly.assertThat(instance.toEntity()).isNotNull();
         } catch (final NullPointerException rEx) {
-            //Assumptions.abort("conversion append on uninitialized fields");
+            Assumptions.abort("conversion append on uninitialized fields");
         } catch (final NetworkModificationException ex) {
-            //Assumptions.abort("internal check on uninitialized field prevent verification");
-        }
-        if (!(instance instanceof ConverterStationCreationInfos)) { //exception because CSCI is included in VscCreationInfos (HVCD case)
-            softly.assertThat(instance.toModification()).isNotNull();
-            try {
-                softly.assertThat(instance.createSubReporter(new ReporterModel("test", "test reporter"))).isNotNull();
-            } catch (final NullPointerException rEx) {
-                //Assumptions.abort("sub reporter template need uninitialized value");
-            }
+            Assumptions.abort("internal check on uninitialized field prevent verification");
         }
     }
 
+    @DisplayName("Check toModification() is override")
+    @ParameterizedTest(name = "for class {0}")
+    @MethodSource("provideTerminalImplementationsWithInstances")
+    void checkMethodsUnsupportedOperationOverrideToModification(final String name, final ModificationInfos instance,
+                                                                final SoftAssertions softly) throws UnsupportedOperationException {
+        //exception because CSCI is included in VscCreationInfos (HVDC case)
+        assumeThat(instance).isNotExactlyInstanceOf(ConverterStationCreationInfos.class);
+        softly.assertThat(instance.toModification()).isNotNull();
+    }
+
+    @DisplayName("Check createSubReporter(...) is override")
+    @ParameterizedTest(name = "for class {0}")
+    @MethodSource("provideTerminalImplementationsWithInstances")
+    void checkMethodsUnsupportedOperationOverrideCreateSubReporter(final String name, final ModificationInfos instance,
+                                                                   final SoftAssertions softly) throws UnsupportedOperationException {
+        //exception because CSCI is included in VscCreationInfos (HVDC case)
+        assumeThat(instance).isNotExactlyInstanceOf(ConverterStationCreationInfos.class);
+        try {
+            softly.assertThat(instance.createSubReporter(new ReporterModel("test", "test reporter"))).isNotNull();
+        } catch (final NullPointerException rEx) {
+            Assumptions.abort("sub reporter template need uninitialized value");
+        }
+    }
+
+    @DisplayName("Check @JsonSubTypes({...}) declare all children")
     @Test
-    void isAllSubTypesDeclared() throws Exception {
+    void isAllSubTypesDeclared() {
         assertThat(ModificationInfos.class.getAnnotation(JsonSubTypes.class).value())
                 .as("ModificationInfos Jackson SubTypes declared")
                 .isNotEmpty()
@@ -166,6 +185,7 @@ class ModificationInfosTest implements WithAssertions, WithAssumptions {
     /*
      * because else error in ModificationInfos.getType()
      */
+    @DisplayName("Check all @JsonTypeName(...) have correct values")
     @ParameterizedTest(name = "{0}")
     @MethodSource("provideTerminalImplementationsWithClasses")
     void isAllJsonNamesValid(final String name, final Class<? extends ModificationInfos> clazz) throws IllegalArgumentException {
@@ -177,6 +197,7 @@ class ModificationInfosTest implements WithAssertions, WithAssumptions {
     /*
      * because else error in ModificationInfos.getErrorType()
      */
+    @DisplayName("Check all @ModificationErrorTypeName(...) have correct values")
     @ParameterizedTest(name = "{0}")
     @MethodSource("provideTerminalImplementationsWithClasses")
     void isAllErrorTypesValid(final String name, final Class<? extends ModificationInfos> clazz) throws IllegalArgumentException {


### PR DESCRIPTION
During a dev in another PR, it was observed that `ModificationInfos.getType()` and `ModificationInfos.getErrorType()` can throw a `NullPointerException` because they try to get annotations who aren't always present.

This PR add a check to prevent this exception, and add some tests to check for children of _ModificationInfos_.