### PR TITLE
Fix reporter "id" attribute name

### DIFF
--- a/src/main/java/org/gridsuite/modification/server/modifications/VoltageInitModification.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/VoltageInitModification.java
@@ -27,13 +27,13 @@ public class VoltageInitModification extends AbstractModification {
     private final VoltageInitModificationInfos voltageInitModificationInfos;
 
     private static final String GENERATOR_KEY = "GeneratorModifications";
-    private static final String GENERATOR_NAME = "Generator ${id}";
+    private static final String GENERATOR_NAME = "Generator ${generatorId}";
     private static final String STATIC_VAR_COMPENSATOR_KEY = "StaticVarCompensatorModifications";
-    private static final String STATIC_VAR_COMPENSATOR_NAME = "Static var compensator ${id}";
+    private static final String STATIC_VAR_COMPENSATOR_NAME = "Static var compensator ${compensatorId}";
     private static final String VSC_CONVERTER_STATION_KEY = "VscConverterStationModifications";
-    private static final String VSC_CONVERTER_STATION_NAME = "Vsc converter station ${id}";
+    private static final String VSC_CONVERTER_STATION_NAME = "Vsc converter station ${converterId}";
     private static final String SHUNT_COMPENSATOR_KEY = "ShuntCompensatorModifications";
-    private static final String SHUNT_COMPENSATOR_NAME = "Shunt compensator ${id}";
+    private static final String SHUNT_COMPENSATOR_NAME = "Shunt compensator ${compensatorId}";
 
     private static final String VOLTAGE_SET_POINT = "Voltage set point";
     private static final String REACTIVE_POWER_SET_POINT = "Reactive power set point";
@@ -69,14 +69,14 @@ public class VoltageInitModification extends AbstractModification {
         for (final VoltageInitGeneratorModificationInfos m : voltageInitModificationInfos.getGenerators()) {
             final Generator generator = network.getGenerator(m.getGeneratorId());
             if (generator == null) {
-                Reporter reporter = subReporter.createSubReporter(GENERATOR_KEY, GENERATOR_NAME, "id", m.getGeneratorId());
+                Reporter reporter = subReporter.createSubReporter(GENERATOR_KEY, GENERATOR_NAME, "generatorId", m.getGeneratorId());
                 reporter.report(Report.builder().withKey("generatorNotFound")
                                                 .withDefaultMessage("Generator with id=${id} not found")
                                                 .withValue("id", m.getGeneratorId())
                                                 .withSeverity(TypedValue.WARN_SEVERITY).build());
             } else if (m.getVoltageSetpoint() != null || m.getReactivePowerSetpoint() != null) {
                 modificationsCount++;
-                Reporter reporter = subReporter.createSubReporter(GENERATOR_KEY, GENERATOR_NAME, "id", m.getGeneratorId());
+                Reporter reporter = subReporter.createSubReporter(GENERATOR_KEY, GENERATOR_NAME, "generatorId", m.getGeneratorId());
                 reporter.report(Report.builder().withKey("generatorModification")
                                                 .withDefaultMessage("Generator with id=${id} modified :")
                                                 .withValue("id", m.getGeneratorId())
@@ -110,7 +110,7 @@ public class VoltageInitModification extends AbstractModification {
             modificationsCount++;
             if (t.getLegSide() != null) {
                 final ThreeWindingsTransformer threeWindingsTransformer = network.getThreeWindingsTransformer(t.getTransformerId());
-                Reporter reporter = subReporter.createSubReporter("3WindingsTransformerModifications", "3 windings transformer ${id}", "id", t.getTransformerId());
+                Reporter reporter = subReporter.createSubReporter("3WindingsTransformerModifications", "3 windings transformer ${transformerId}", "transformerId", t.getTransformerId());
                 if (threeWindingsTransformer == null) {
                     reporter.report(Report.builder().withKey("3WindingsTransformerNotFound")
                                                     .withDefaultMessage("3 windings transformer with id=${id} not found")
@@ -133,7 +133,7 @@ public class VoltageInitModification extends AbstractModification {
                 }
             } else {
                 final TwoWindingsTransformer twoWindingsTransformer = network.getTwoWindingsTransformer(t.getTransformerId());
-                Reporter reporter = subReporter.createSubReporter("2WindingsTransformerModifications", "2 windings transformer ${id}", "id", t.getTransformerId());
+                Reporter reporter = subReporter.createSubReporter("2WindingsTransformerModifications", "2 windings transformer ${transformerId}", "transformerId", t.getTransformerId());
                 if (twoWindingsTransformer == null) {
                     reporter.report(Report.builder().withKey("2WindingsTransformerNotFound")
                                                     .withDefaultMessage("2 windings transformer with id=${id} not found")
@@ -168,14 +168,14 @@ public class VoltageInitModification extends AbstractModification {
         for (VoltageInitStaticVarCompensatorModificationInfos s : voltageInitModificationInfos.getStaticVarCompensators()) {
             final StaticVarCompensator staticVarCompensator = network.getStaticVarCompensator(s.getStaticVarCompensatorId());
             if (staticVarCompensator == null) {
-                Reporter reporter = subReporter.createSubReporter(STATIC_VAR_COMPENSATOR_KEY, STATIC_VAR_COMPENSATOR_NAME, "id", s.getStaticVarCompensatorId());
+                Reporter reporter = subReporter.createSubReporter(STATIC_VAR_COMPENSATOR_KEY, STATIC_VAR_COMPENSATOR_NAME, "compensatorId", s.getStaticVarCompensatorId());
                 reporter.report(Report.builder().withKey("staticVarCompensatorNotFound")
                                                 .withDefaultMessage("Static var compensator with id=${id} not found")
                                                 .withValue("id", s.getStaticVarCompensatorId())
                                                 .withSeverity(TypedValue.WARN_SEVERITY).build());
             } else if (s.getVoltageSetpoint() != null || s.getReactivePowerSetpoint() != null) {
                 modificationsCount++;
-                Reporter reporter = subReporter.createSubReporter(STATIC_VAR_COMPENSATOR_KEY, STATIC_VAR_COMPENSATOR_NAME, "id", s.getStaticVarCompensatorId());
+                Reporter reporter = subReporter.createSubReporter(STATIC_VAR_COMPENSATOR_KEY, STATIC_VAR_COMPENSATOR_NAME, "compensatorId", s.getStaticVarCompensatorId());
                 reporter.report(Report.builder().withKey("staticVarCompensatorModification")
                                                 .withDefaultMessage("Static var compensator with id=${id} modified :")
                                                 .withValue("id", s.getStaticVarCompensatorId())
@@ -205,14 +205,14 @@ public class VoltageInitModification extends AbstractModification {
         for (VoltageInitVscConverterStationModificationInfos v : voltageInitModificationInfos.getVscConverterStations()) {
             final VscConverterStation vscConverterStation = network.getVscConverterStation(v.getVscConverterStationId());
             if (vscConverterStation == null) {
-                Reporter reporter = subReporter.createSubReporter(VSC_CONVERTER_STATION_KEY, VSC_CONVERTER_STATION_NAME, "id", v.getVscConverterStationId());
+                Reporter reporter = subReporter.createSubReporter(VSC_CONVERTER_STATION_KEY, VSC_CONVERTER_STATION_NAME, "converterId", v.getVscConverterStationId());
                 reporter.report(Report.builder().withKey("vscConverterStationNotFound")
                                                 .withDefaultMessage("Vsc converter station with id=${id} not found")
                                                 .withValue("id", v.getVscConverterStationId())
                                                 .withSeverity(TypedValue.WARN_SEVERITY).build());
             } else if (v.getVoltageSetpoint() != null || v.getReactivePowerSetpoint() != null) {
                 modificationsCount++;
-                Reporter reporter = subReporter.createSubReporter(VSC_CONVERTER_STATION_KEY, VSC_CONVERTER_STATION_NAME, "id", v.getVscConverterStationId());
+                Reporter reporter = subReporter.createSubReporter(VSC_CONVERTER_STATION_KEY, VSC_CONVERTER_STATION_NAME, "converterId", v.getVscConverterStationId());
                 reporter.report(Report.builder().withKey("vscConverterStationModification")
                                                 .withDefaultMessage("Vsc converter station with id=${id} modified :")
                                                 .withValue("id", v.getVscConverterStationId())
@@ -242,7 +242,7 @@ public class VoltageInitModification extends AbstractModification {
         for (VoltageInitShuntCompensatorModificationInfos m : voltageInitModificationInfos.getShuntCompensators()) {
             final ShuntCompensator shuntCompensator = network.getShuntCompensator(m.getShuntCompensatorId());
             if (shuntCompensator == null) {
-                Reporter reporter = subReporter.createSubReporter(SHUNT_COMPENSATOR_KEY, SHUNT_COMPENSATOR_NAME, "id", m.getShuntCompensatorId());
+                Reporter reporter = subReporter.createSubReporter(SHUNT_COMPENSATOR_KEY, SHUNT_COMPENSATOR_NAME, "compensatorId", m.getShuntCompensatorId());
                 reporter.report(Report.builder().withKey("shuntCompensatorNotFound")
                                                 .withDefaultMessage("Shunt compensator with id=${id} not found")
                                                 .withValue("id", m.getShuntCompensatorId())
@@ -288,7 +288,7 @@ public class VoltageInitModification extends AbstractModification {
                 }
                 if (!reports.isEmpty()) {
                     modificationsCount++;
-                    Reporter reporter = subReporter.createSubReporter(SHUNT_COMPENSATOR_KEY, SHUNT_COMPENSATOR_NAME, "id", m.getShuntCompensatorId());
+                    Reporter reporter = subReporter.createSubReporter(SHUNT_COMPENSATOR_KEY, SHUNT_COMPENSATOR_NAME, "compensatorId", m.getShuntCompensatorId());
                     reporter.report(Report.builder().withKey("shuntCompensatorModification")
                                                     .withDefaultMessage("Shunt compensator with id=${id} modified :")
                                                     .withValue("id", m.getShuntCompensatorId())

--- a/src/test/resources/reports_voltage_init_modification_ok.json
+++ b/src/test/resources/reports_voltage_init_modification_ok.json
@@ -4,7 +4,8 @@
     "taskKey" : "99999999-9999-9999-9999-999999999999@NetworkModification",
     "subReporters" : [ {
       "taskKey" : "VOLTAGE_INIT_MODIFICATION",
-      "reports" : [ {
+      "reports" : [
+        {
         "reportKey" : "generatorModificationsResume",
         "values" : {
           "reportSeverity" : {
@@ -63,11 +64,12 @@
       "subReporters" : [ {
         "taskKey" : "GeneratorModifications",
         "taskValues" : {
-          "id" : {
+          "generatorId" : {
             "value" : "GTH2"
           }
         },
-        "reports" : [ {
+        "reports" : [
+          {
           "reportKey" : "generatorModification",
           "values" : {
             "reportSeverity" : {
@@ -99,11 +101,12 @@
       }, {
         "taskKey" : "2WindingsTransformerModifications",
         "taskValues" : {
-          "id" : {
+          "transformerId" : {
             "value" : "TWT2"
           }
         },
-        "reports" : [ {
+        "reports" : [
+          {
           "reportKey" : "2WindingsTransformerModification",
           "values" : {
             "reportSeverity" : {
@@ -135,7 +138,7 @@
       }, {
         "taskKey" : "StaticVarCompensatorModifications",
         "taskValues" : {
-          "id" : {
+          "compensatorId" : {
             "value" : "SVC"
           }
         },
@@ -171,7 +174,7 @@
       }, {
         "taskKey" : "ShuntCompensatorModifications",
         "taskValues" : {
-          "id" : {
+          "compensatorId" : {
             "value" : "SHUNT3"
           }
         },
@@ -215,7 +218,7 @@
       }, {
         "taskKey" : "VscConverterStationModifications",
         "taskValues" : {
-          "id" : {
+          "converterId" : {
             "value" : "VSC2"
           }
         },
@@ -256,19 +259,19 @@
       "99999999-9999-9999-9999-999999999999@NetworkModification" : "99999999-9999-9999-9999-999999999999@NetworkModification",
       "VOLTAGE_INIT_MODIFICATION" : "Voltage init modification",
       "modification-indent1" : "\t${fieldName} : ${oldValue} → ${newValue}",
-      "GeneratorModifications" : "Generator ${id}",
+      "GeneratorModifications" : "Generator ${generatorId}",
       "generatorModification" : "Generator with id=${id} modified :",
       "generatorModificationsResume" : "${count} generator(s) have been modified.",
-      "2WindingsTransformerModifications" : "2 windings transformer ${id}",
+      "2WindingsTransformerModifications" : "2 windings transformer ${transformerId}",
       "2WindingsTransformerModification" : "2 windings transformer with id=${id} modified :",
       "windingsTransformerModificationsResume" : "${count} transformer(s) have been modified.",
-      "VscConverterStationModifications" : "Vsc converter station ${id}",
+      "VscConverterStationModifications" : "Vsc converter station ${converterId}",
       "vscConverterStationModification" : "Vsc converter station with id=${id} modified :",
       "vscModificationsResume" : "${count} vsc converter station(s) have been modified.",
-      "StaticVarCompensatorModifications" : "Static var compensator ${id}",
+      "StaticVarCompensatorModifications" : "Static var compensator ${compensatorId}",
       "staticVarCompensatorModification" : "Static var compensator with id=${id} modified :",
       "svcModificationsResume" : "${count} static var compensator(s) have been modified.",
-      "ShuntCompensatorModifications" : "Shunt compensator ${id}",
+      "ShuntCompensatorModifications" : "Shunt compensator ${compensatorId}",
       "shuntCompensatorModification" : "Shunt compensator with id=${id} modified :",
       "shuntCompensatorDisconnected" : "\tShunt compensator disconnected",
       "shuntCompensatorModificationsResume" : "${count} shunt compensator(s) have been modified."

--- a/src/test/resources/reports_voltage_init_modification_warnings.json
+++ b/src/test/resources/reports_voltage_init_modification_warnings.json
@@ -30,7 +30,7 @@
       "subReporters" : [ {
         "taskKey" : "GeneratorModifications",
         "taskValues" : {
-          "id" : {
+          "generatorId" : {
             "value" : "G1"
           }
         },
@@ -49,7 +49,7 @@
       }, {
         "taskKey" : "GeneratorModifications",
         "taskValues" : {
-          "id" : {
+          "generatorId" : {
             "value" : "G2"
           }
         },
@@ -68,7 +68,7 @@
       }, {
         "taskKey" : "2WindingsTransformerModifications",
         "taskValues" : {
-          "id" : {
+          "transformerId" : {
             "value" : "2WT1"
           }
         },
@@ -87,7 +87,7 @@
       }, {
         "taskKey" : "3WindingsTransformerModifications",
         "taskValues" : {
-          "id" : {
+          "transformerId" : {
             "value" : "3WT1"
           }
         },
@@ -106,7 +106,7 @@
       }, {
         "taskKey" : "StaticVarCompensatorModifications",
         "taskValues" : {
-          "id" : {
+          "compensatorId" : {
             "value" : "SVC1"
           }
         },
@@ -125,7 +125,7 @@
       }, {
         "taskKey" : "StaticVarCompensatorModifications",
         "taskValues" : {
-          "id" : {
+          "compensatorId" : {
             "value" : "SVC2"
           }
         },
@@ -144,7 +144,7 @@
       }, {
         "taskKey" : "ShuntCompensatorModifications",
         "taskValues" : {
-          "id" : {
+          "compensatorId" : {
             "value" : "v2shunt"
           }
         },
@@ -163,7 +163,7 @@
       }, {
         "taskKey" : "ShuntCompensatorModifications",
         "taskValues" : {
-          "id" : {
+          "compensatorId" : {
             "value" : "v5shunt"
           }
         },
@@ -182,7 +182,7 @@
       }, {
         "taskKey" : "ShuntCompensatorModifications",
         "taskValues" : {
-          "id" : {
+          "compensatorId" : {
             "value" : "v6shunt"
           }
         },
@@ -201,7 +201,7 @@
       }, {
         "taskKey" : "VscConverterStationModifications",
         "taskValues" : {
-          "id" : {
+          "converterId" : {
             "value" : "VSC1"
           }
         },
@@ -237,7 +237,7 @@
       }, {
         "taskKey" : "VscConverterStationModifications",
         "taskValues" : {
-          "id" : {
+          "converterId" : {
             "value" : "VSC2"
           }
         },
@@ -277,21 +277,21 @@
     "default" : {
       "99999999-9999-9999-9999-999999999999@NetworkModification" : "99999999-9999-9999-9999-999999999999@NetworkModification",
       "VOLTAGE_INIT_MODIFICATION" : "Voltage init modification",
-      "windingsTransformerModificationsResume" : "${count} transformer(s) have been modified.",
-      "GeneratorModifications" : "Generator ${id}",
-      "ShuntCompensatorModifications" : "Shunt compensator ${id}",
-      "staticVarCompensatorNotFound" : "Static var compensator with id=${id} not found",
-      "StaticVarCompensatorModifications" : "Static var compensator ${id}",
-      "vscConverterStationModification" : "Vsc converter station with id=${id} modified :",
       "modification-indent1" : "\t${fieldName} : ${oldValue} → ${newValue}",
-      "3WindingsTransformerModifications" : "3 windings transformer ${id}",
+      "GeneratorModifications" : "Generator ${generatorId}",
+      "generatorNotFound" : "Generator with id=${id} not found",
+      "2WindingsTransformerModifications" : "2 windings transformer ${transformerId}",
       "2WindingsTransformerNotFound" : "2 windings transformer with id=${id} not found",
-      "vscModificationsResume" : "${count} vsc converter station(s) have been modified.",
-      "shuntCompensatorNotFound" : "Shunt compensator with id=${id} not found",
-      "VscConverterStationModifications" : "Vsc converter station ${id}",
+      "3WindingsTransformerModifications" : "3 windings transformer ${transformerId}",
       "3WindingsTransformerNotFound" : "3 windings transformer with id=${id} not found",
-      "2WindingsTransformerModifications" : "2 windings transformer ${id}",
-      "generatorNotFound" : "Generator with id=${id} not found"
+      "windingsTransformerModificationsResume" : "${count} transformer(s) have been modified.",
+      "VscConverterStationModifications" : "Vsc converter station ${converterId}",
+      "vscConverterStationModification" : "Vsc converter station with id=${id} modified :",
+      "vscModificationsResume" : "${count} vsc converter station(s) have been modified.",
+      "StaticVarCompensatorModifications" : "Static var compensator ${compensatorId}",
+      "staticVarCompensatorNotFound" : "Static var compensator with id=${id} not found",
+      "ShuntCompensatorModifications" : "Shunt compensator ${compensatorId}",
+      "shuntCompensatorNotFound" : "Shunt compensator with id=${id} not found"
     }
   }
 }


### PR DESCRIPTION
Fix for #366:

Fix attribute `id` use in name of `Reporter`, which is already used by report-server for gridstudy-app (ie. [ReportService.java#L145](https://github.com/gridsuite/report-server/blob/f5d79efe9ddea8e72d1ac64e9430036341f1395a/src/main/java/org/gridsuite/report/server/ReportService.java#L145)).

![image](https://github.com/gridsuite/network-modification-server/assets/135599584/eb1ac241-5a09-4c4a-8935-f391e071454d)
