### PR TITLE
fix issue about subreporter uniqueness in line creation

### DIFF
--- a/src/main/java/org/gridsuite/modification/server/dto/LineCreationInfos.java
+++ b/src/main/java/org/gridsuite/modification/server/dto/LineCreationInfos.java
@@ -58,6 +58,6 @@ public class LineCreationInfos extends BranchCreationInfos {
 
     @Override
     public Reporter createSubReporter(ReporterModel reporter) {
-        return reporter.createSubReporter(getType().name(), "Creation of line " + getEquipmentId());
+        return reporter.createSubReporter(getType().name(), "Creation of line ${lineId}", "lineId", getEquipmentId());
     }
 }


### PR DESCRIPTION
the LINE_CREATION subreporter must have a {lineId} parameter to ensure all subreporters uniqueness