### PR TITLE
Optimize SQL queries when getting tabular modification of generators

### DIFF
--- a/src/main/java/org/gridsuite/modification/server/repositories/NetworkModificationRepository.java
+++ b/src/main/java/org/gridsuite/modification/server/repositories/NetworkModificationRepository.java
@@ -177,10 +177,10 @@ public class NetworkModificationRepository {
         Stream<ModificationEntity> modificationEntity = groupUuids.stream().flatMap(this::getModificationEntityStream);
         if (onlyStashed) {
             return modificationEntity.filter(m -> m.getStashed() == onlyStashed)
-                    .map(ModificationEntity::toModificationInfos)
+                    .map(this::getModificationInfos)
                     .collect(Collectors.toList());
         } else {
-            return modificationEntity.map(ModificationEntity::toModificationInfos)
+            return modificationEntity.map(this::getModificationInfos)
                 .collect(Collectors.toList());
         }
     }

--- a/src/test/java/org/gridsuite/modification/server/modifications/tabularmodifications/TabularGeneratorModificationsTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/tabularmodifications/TabularGeneratorModificationsTest.java
@@ -120,6 +120,13 @@ public class TabularGeneratorModificationsTest extends AbstractNetworkModificati
                 .andReturn();
         // We check that the request count is not dependent on the number of sub modifications of the tabular modification (the JPA N+1 problem is correctly solved)
         assertSelectCount(3);
+        reset();
+
+        // Now we get back the 2 tabular modifications
+        mockMvc.perform(get("/v1/groups/{groupUuid}/network-modifications", getGroupId()))
+                .andExpect(status().isOk());
+        // We check that the request count is not dependent on the number of sub modifications of the tabular modification (the JPA N+1 problem is correctly solved)
+        assertSelectCount(6);
     }
 
     @Test

--- a/src/test/java/org/gridsuite/modification/server/modifications/tabularmodifications/TabularGeneratorModificationsTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/tabularmodifications/TabularGeneratorModificationsTest.java
@@ -122,7 +122,7 @@ public class TabularGeneratorModificationsTest extends AbstractNetworkModificati
         assertSelectCount(3);
         reset();
 
-        // Now we get back the 2 tabular modifications
+        // We get the modifications of the group (so the 2 tabular modifications)
         mockMvc.perform(get("/v1/groups/{groupUuid}/network-modifications", getGroupId()))
                 .andExpect(status().isOk());
         // We check that the request count is not dependent on the number of sub modifications of the tabular modification (the JPA N+1 problem is correctly solved)


### PR DESCRIPTION
Fix the n+1 problem when building a node with generators tabular modification.
We just have to call the right method already implemented.