### PR TITLE
make sure we use same filter lib version than filter-server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <log4j2-mock-version>0.0.2</log4j2-mock-version>
         <testcontainers.version>1.16.2</testcontainers.version>
         <liquibase-hibernate-package>org.gridsuite.modification.server</liquibase-hibernate-package>
-        <gridsuite-filter.version>1.0.2</gridsuite-filter.version>
+        <gridsuite-filter.version>1.0.4</gridsuite-filter.version>
     </properties>
 
     <build>


### PR DESCRIPTION
Make sure we use same filter lib version than filter-server. In my case (v 1.0.2 vs 1.0.4) I could not read properties sent by the filter-server.
Tested:
- test delete by filter using properties filter:
  - ok: generator,substation,Line,Load,VL,2wt,mcs,battery,
  - with all other equipments, we cannot create a filter on eqpt properties, and we cannot create/modify properties on them

- test update by formula using properties filter:
same, but substation/line not updatable by formula