### PR TITLE
Use voltageLevelId to improve getBus() lookup time

### DIFF
--- a/src/main/java/org/gridsuite/modification/server/ModificationType.java
+++ b/src/main/java/org/gridsuite/modification/server/ModificationType.java
@@ -44,7 +44,7 @@ public enum ModificationType {
     DELETE_VOLTAGE_LEVEL_ON_LINE(PreloadingStrategy.NONE),
     DELETE_ATTACHING_LINE(PreloadingStrategy.NONE),
     GENERATION_DISPATCH(PreloadingStrategy.COLLECTION),
-    VOLTAGE_INIT_MODIFICATION(PreloadingStrategy.COLLECTION),
+    VOLTAGE_INIT_MODIFICATION(PreloadingStrategy.ALL_COLLECTIONS_NEEDED_FOR_BUS_VIEW),
     VSC_CREATION(PreloadingStrategy.NONE),
     VSC_MODIFICATION(PreloadingStrategy.NONE),
     CONVERTER_STATION_CREATION(PreloadingStrategy.NONE),

--- a/src/main/java/org/gridsuite/modification/server/dto/VoltageInitBusModificationInfos.java
+++ b/src/main/java/org/gridsuite/modification/server/dto/VoltageInitBusModificationInfos.java
@@ -23,6 +23,9 @@ import lombok.experimental.SuperBuilder;
 @Setter
 @Schema(description = "Voltage init bus modfication infos")
 public class VoltageInitBusModificationInfos {
+    @Schema(description = "Voltage level id")
+    private String voltageLevelId;
+
     @Schema(description = "Bus id")
     private String busId;
 

--- a/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/VoltageInitBusModificationEmbeddable.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/VoltageInitBusModificationEmbeddable.java
@@ -24,6 +24,9 @@ import jakarta.persistence.Embeddable;
 @Embeddable
 public class VoltageInitBusModificationEmbeddable {
     @Column
+    private String voltageLevelId;
+
+    @Column
     private String busId;
 
     @Column

--- a/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/VoltageInitModificationEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/VoltageInitModificationEntity.java
@@ -163,14 +163,14 @@ public class VoltageInitModificationEntity extends ModificationEntity {
 
     public static List<VoltageInitBusModificationEmbeddable> toEmbeddableVoltageInitBuses(List<VoltageInitBusModificationInfos> buses) {
         return buses == null ? null : buses.stream()
-            .map(bus -> new VoltageInitBusModificationEmbeddable(bus.getBusId(), bus.getV(), bus.getAngle()))
+            .map(bus -> new VoltageInitBusModificationEmbeddable(bus.getVoltageLevelId(), bus.getBusId(), bus.getV(), bus.getAngle()))
             .collect(Collectors.toList());
     }
 
     private List<VoltageInitBusModificationInfos> toBusesModification(List<VoltageInitBusModificationEmbeddable> buses) {
         return buses != null ? buses
             .stream()
-            .map(bus -> new VoltageInitBusModificationInfos(bus.getBusId(), bus.getV(), bus.getAngle()))
+            .map(bus -> new VoltageInitBusModificationInfos(bus.getVoltageLevelId(), bus.getBusId(), bus.getV(), bus.getAngle()))
             .collect(Collectors.toList()) : null;
     }
 

--- a/src/main/java/org/gridsuite/modification/server/modifications/VoltageInitModification.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/VoltageInitModification.java
@@ -17,9 +17,6 @@ import org.gridsuite.modification.server.dto.*;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static org.gridsuite.modification.server.modifications.ModificationUtils.insertReportNode;
 
@@ -81,11 +78,9 @@ public class VoltageInitModification extends AbstractModification {
     private void applyBusModification(Network network, ReportNode subReportNode) {
         int modificationsCount = 0;
         List<ReportNode> reports = new ArrayList<>();
-        // Cache buses by ID to optimize lookup times and avoid repeated iterations over voltage levels and buses in the store.
-        // The bus view remains valid for all iterations as we only set voltage magnitude and angle.
-        Map<String, Bus> busCache = network.getBusView().getBusStream().collect(Collectors.toMap(Bus::getId, Function.identity()));
         for (VoltageInitBusModificationInfos m : voltageInitModificationInfos.getBuses()) {
-            final Bus bus = busCache.get(m.getBusId());
+            final VoltageLevel voltageLevel = network.getVoltageLevel(m.getVoltageLevelId());
+            final Bus bus = voltageLevel.getBusView().getBus(m.getBusId());
             if (bus == null) {
                 reports.add(ReportNode.newRootReportNode()
                         .withMessageTemplate("busNotFound", "Bus with id=${id} not found")

--- a/src/main/java/org/gridsuite/modification/server/modifications/VoltageInitModification.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/VoltageInitModification.java
@@ -79,8 +79,14 @@ public class VoltageInitModification extends AbstractModification {
         int modificationsCount = 0;
         List<ReportNode> reports = new ArrayList<>();
         for (VoltageInitBusModificationInfos m : voltageInitModificationInfos.getBuses()) {
-            final VoltageLevel voltageLevel = network.getVoltageLevel(m.getVoltageLevelId());
-            final Bus bus = voltageLevel.getBusView().getBus(m.getBusId());
+            String voltageLevelId = m.getVoltageLevelId();
+            Bus bus;
+            if (voltageLevelId != null) {
+                final VoltageLevel voltageLevel = network.getVoltageLevel(voltageLevelId);
+                bus = voltageLevel.getBusView().getBus(m.getBusId());
+            } else {
+                bus = network.getBusView().getBus(m.getBusId());
+            }
             if (bus == null) {
                 reports.add(ReportNode.newRootReportNode()
                         .withMessageTemplate("busNotFound", "Bus with id=${id} not found")

--- a/src/main/java/org/gridsuite/modification/server/modifications/VoltageInitModification.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/VoltageInitModification.java
@@ -17,6 +17,9 @@ import org.gridsuite.modification.server.dto.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.gridsuite.modification.server.modifications.ModificationUtils.insertReportNode;
 
@@ -78,8 +81,11 @@ public class VoltageInitModification extends AbstractModification {
     private void applyBusModification(Network network, ReportNode subReportNode) {
         int modificationsCount = 0;
         List<ReportNode> reports = new ArrayList<>();
+        // Cache buses by ID to optimize lookup times and avoid repeated iterations over voltage levels and buses in the store.
+        // The bus view remains valid for all iterations as we only set voltage magnitude and angle.
+        Map<String, Bus> busCache = network.getBusView().getBusStream().collect(Collectors.toMap(Bus::getId, Function.identity()));
         for (VoltageInitBusModificationInfos m : voltageInitModificationInfos.getBuses()) {
-            final Bus bus = network.getBusView().getBus(m.getBusId());
+            final Bus bus = busCache.get(m.getBusId());
             if (bus == null) {
                 reports.add(ReportNode.newRootReportNode()
                         .withMessageTemplate("busNotFound", "Bus with id=${id} not found")

--- a/src/main/resources/db/changelog/changesets/changelog_20240709T090545Z.xml
+++ b/src/main/resources/db/changelog/changesets/changelog_20240709T090545Z.xml
@@ -1,0 +1,8 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet author="lecuyerfra (generated)" id="1720515985912-29">
+        <addColumn tableName="voltage_init_bus_modification">
+            <column name="voltage_level_id" type="varchar(255)"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -297,3 +297,6 @@ databaseChangeLog:
   - include:
       file: changesets/changelog_20240617T212921Z.xml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/changelog_20240709T090545Z.xml
+      relativeToChangelogFile: true

--- a/src/test/java/org/gridsuite/modification/server/ModificationControllerTest.java
+++ b/src/test/java/org/gridsuite/modification/server/ModificationControllerTest.java
@@ -1417,11 +1417,13 @@ public class ModificationControllerTest {
                     .build()))
             .buses(List.of(
                 VoltageInitBusModificationInfos.builder()
+                    .voltageLevelId("v1")
                     .busId("1.1")
                     .v(225.)
                     .angle(0.)
                     .build(),
                 VoltageInitBusModificationInfos.builder()
+                    .voltageLevelId("v1")
                     .busId("1.2")
                     .v(226.)
                     .angle(0.6)

--- a/src/test/java/org/gridsuite/modification/server/modifications/VoltageInitModificationTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/VoltageInitModificationTest.java
@@ -192,11 +192,13 @@ public class VoltageInitModificationTest extends AbstractNetworkModificationTest
                     .build()))
             .buses(List.of(
                 VoltageInitBusModificationInfos.builder()
+                    .voltageLevelId("v2")
                     .busId("busNotFound")
                     .v(400.)
                     .angle(0.)
                     .build(),
                 VoltageInitBusModificationInfos.builder()
+                    .voltageLevelId("v1")
                     .busId("v1_0")
                     .v(230.)
                     .angle(0.5)

--- a/src/test/java/org/gridsuite/modification/server/service/ModificationRepositoryTest.java
+++ b/src/test/java/org/gridsuite/modification/server/service/ModificationRepositoryTest.java
@@ -1190,11 +1190,13 @@ public class ModificationRepositoryTest {
                     .build()))
             .buses(List.of(
                 VoltageInitBusModificationInfos.builder()
+                    .voltageLevelId("1")
                     .busId("B1")
                     .v(225.)
                     .angle(0.)
                     .build(),
                 VoltageInitBusModificationInfos.builder()
+                    .voltageLevelId("2")
                     .busId("B2")
                     .v(380.)
                     .angle(0.3)


### PR DESCRIPTION
While doing tests with the profiler on VoltageInitModification, I found an issue on the getBus(id) for the VoltageInit modification. As buses are not cache, it takes forever to retrieve the buses using the lookup getBus(id) at each iteration.
Before this PR the time taken to apply a voltage-init modification was about 30s, after it will be around 5-10s.