### PR TITLE
Fix converter station modification issue in unbuilt state

### DIFF
--- a/src/main/java/org/gridsuite/modification/server/modifications/VscModification.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/VscModification.java
@@ -61,7 +61,6 @@ public class VscModification extends AbstractModification {
 
         checkToModifyDroop();
 
-
     }
 
     private void checkToModifyDroop() {

--- a/src/main/java/org/gridsuite/modification/server/modifications/VscModification.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/VscModification.java
@@ -59,26 +59,16 @@ public class VscModification extends AbstractModification {
         checkConverterStation(modificationInfos.getConverterStation1(), converterStation1);
         checkConverterStation(modificationInfos.getConverterStation2(), converterStation2);
 
-        boolean po = checkIfPossibleToModifyP0(hvdcLine);
-        if (!po) {
-            throw new NetworkModificationException(MODIFY_VSC_ERROR, "P0 is required to modify the equipment");
-        }
+        checkToModifyDroop();
+
 
     }
 
-    private boolean checkIfPossibleToModifyP0(HvdcLine hvdcLine) {
-        var hvdcAngleDroopActivePowerControl = hvdcLine.getExtension(HvdcAngleDroopActivePowerControl.class);
-        // if droop is not set but p0 is set, we can't modify the p0
-        if (hvdcAngleDroopActivePowerControl == null && modificationInfos.getDroop() == null && modificationInfos.getP0() != null) {
-            return false;
+    private void checkToModifyDroop() {
+        // if droop is set p0 should be also
+        if (modificationInfos.getP0() != null || modificationInfos.getDroop() == null) {
+            throw new NetworkModificationException(MODIFY_VSC_ERROR, "P0 is required to modify the equipment");
         }
-
-        if (hvdcAngleDroopActivePowerControl != null && (Float.isNaN(hvdcAngleDroopActivePowerControl.getDroop())
-                || modificationInfos.getDroop() != null) && modificationInfos.getP0() == null) {
-            return false;
-        }
-
-        return true;
     }
 
     @Override

--- a/src/main/java/org/gridsuite/modification/server/modifications/VscModification.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/VscModification.java
@@ -58,11 +58,11 @@ public class VscModification extends AbstractModification {
         checkConverterStation(modificationInfos.getConverterStation1(), converterStation1);
         checkConverterStation(modificationInfos.getConverterStation2(), converterStation2);
 
-        checkToModifyDroop();
+        isDropModificationAllowed();
 
     }
 
-    private void checkToModifyDroop() {
+    private void isDropModificationAllowed() {
         // if droop is set p0 should be also
         if (modificationInfos.getP0() == null && modificationInfos.getDroop() != null) {
             throw new NetworkModificationException(MODIFY_VSC_ERROR, "P0 is required to modify the equipment");

--- a/src/main/java/org/gridsuite/modification/server/modifications/VscModification.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/VscModification.java
@@ -52,8 +52,9 @@ public class VscModification extends AbstractModification {
                 || modificationInfos.getConverterStation2() == null) {
             throw new NetworkModificationException(MODIFY_BATTERY_ERROR, "Missing required attributes to modify the equipment");
         }
-        VscConverterStation converterStation1 = ModificationUtils.getInstance().getVscConverterStation(network, modificationInfos.getConverterStation1().getEquipmentId());
-        VscConverterStation converterStation2 = ModificationUtils.getInstance().getVscConverterStation(network, modificationInfos.getConverterStation2().getEquipmentId());
+        HvdcLine hvdcLine = ModificationUtils.getInstance().getHvdcLine(network, modificationInfos.getEquipmentId());
+        VscConverterStation converterStation1 = ModificationUtils.getInstance().getVscConverterStation(network, hvdcLine.getConverterStation1().getId());
+        VscConverterStation converterStation2 = ModificationUtils.getInstance().getVscConverterStation(network, hvdcLine.getConverterStation2().getId());
         checkConverterStation(modificationInfos.getConverterStation1(), converterStation1);
         checkConverterStation(modificationInfos.getConverterStation2(), converterStation2);
     }
@@ -94,8 +95,8 @@ public class VscModification extends AbstractModification {
 
         hvdcAngleDroopActivePowerControlAdder(hvdcLine, subReportNode);
 
-        modifyConverterStation(network, modificationInfos.getConverterStation1(), subReportNode);
-        modifyConverterStation(network, modificationInfos.getConverterStation2(), subReportNode);
+        modifyConverterStation(ModificationUtils.getInstance().getVscConverterStation(network, hvdcLine.getConverterStation1().getId()), modificationInfos.getConverterStation1(), subReportNode);
+        modifyConverterStation(ModificationUtils.getInstance().getVscConverterStation(network, hvdcLine.getConverterStation2().getId()), modificationInfos.getConverterStation2(), subReportNode);
 
         PropertiesUtils.applyProperties(hvdcLine, subReportNode, modificationInfos.getProperties(), "VscProperties");
     }
@@ -212,11 +213,10 @@ public class VscModification extends AbstractModification {
         reports.forEach(report -> insertReportNode(subReportNode, report));
     }
 
-    private void modifyConverterStation(Network network, ConverterStationModificationInfos converterStationModificationInfos, ReportNode subReportNode) {
+    private void modifyConverterStation(VscConverterStation converterStation, ConverterStationModificationInfos converterStationModificationInfos, ReportNode subReportNode) {
         if (converterStationModificationInfos == null) {
             return;
         }
-        VscConverterStation converterStation = ModificationUtils.getInstance().getVscConverterStation(network, converterStationModificationInfos.getEquipmentId());
         if (!isConverterStationModified(converterStationModificationInfos)) {
             return;
         }

--- a/src/main/java/org/gridsuite/modification/server/modifications/VscModification.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/VscModification.java
@@ -58,11 +58,11 @@ public class VscModification extends AbstractModification {
         checkConverterStation(modificationInfos.getConverterStation1(), converterStation1);
         checkConverterStation(modificationInfos.getConverterStation2(), converterStation2);
 
-        isDropModificationAllowed();
+        checkDroopModification();
 
     }
 
-    private void isDropModificationAllowed() {
+    private void checkDroopModification() {
         // if droop is set p0 should be also
         if (modificationInfos.getP0() == null && modificationInfos.getDroop() != null) {
             throw new NetworkModificationException(MODIFY_VSC_ERROR, "P0 is required to modify the equipment");

--- a/src/main/java/org/gridsuite/modification/server/modifications/VscModification.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/VscModification.java
@@ -64,7 +64,7 @@ public class VscModification extends AbstractModification {
 
     private void checkToModifyDroop() {
         // if droop is set p0 should be also
-        if (modificationInfos.getP0() != null || modificationInfos.getDroop() == null) {
+        if (modificationInfos.getP0() == null && modificationInfos.getDroop() != null) {
             throw new NetworkModificationException(MODIFY_VSC_ERROR, "P0 is required to modify the equipment");
         }
     }

--- a/src/test/java/org/gridsuite/modification/server/modifications/VscModificationTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/VscModificationTest.java
@@ -63,8 +63,8 @@ public class VscModificationTest extends AbstractNetworkModificationTest {
                 .operatorActivePowerLimitFromSide2ToSide1(new AttributeModification<>(8F, OperationType.SET))
                 .droop(new AttributeModification<>(1F, OperationType.SET))
                 .angleDroopActivePowerControl(new AttributeModification<>(true, OperationType.SET))
-                .converterStation1(buildConverterStationWithMinMaxReactiveLimits())
-                .converterStation2(buildConverterStationWithReactiveCapabilityCurve())
+                .converterStation1(buildConverterStationWithReactiveCapabilityCurve())
+                .converterStation2(buildConverterStationWithMinMaxReactiveLimits())
                 .properties(List.of(FreePropertyInfos.builder().name(PROPERTY_NAME).value(PROPERTY_VALUE).build()))
                 .build();
     }
@@ -171,7 +171,7 @@ public class VscModificationTest extends AbstractNetworkModificationTest {
             Assert.assertEquals(2, reactiveLimits1.getPointCount());
             Collection<ReactiveCapabilityCurve.Point> points = vscConverterStation1.getReactiveLimits(ReactiveCapabilityCurve.class).getPoints();
             List<ReactiveCapabilityCurve.Point> vscPoints = new ArrayList<>(points);
-            List<ReactiveCapabilityCurveModificationInfos> modificationPoints = vscModificationInfos.getConverterStation2().getReactiveCapabilityCurvePoints();
+            List<ReactiveCapabilityCurveModificationInfos> modificationPoints = vscModificationInfos.getConverterStation1().getReactiveCapabilityCurvePoints();
             if (!CollectionUtils.isEmpty(points)) {
                 IntStream.range(0, vscPoints.size())
                         .forEach(i -> {

--- a/src/test/java/org/gridsuite/modification/server/modifications/VscModificationTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/VscModificationTest.java
@@ -262,19 +262,26 @@ public class VscModificationTest extends AbstractNetworkModificationTest {
         Assert.assertTrue(activePowerControl.isEnabled());
     }
 
-    //Test : p0 sould be required if drop is enabled
     @Test
     public void testHvdcAngleDroopActivePowerControlWithoutP0() {
         var networkuuid = UUID.randomUUID();
         Network networkWitoutExt = NetworkCreation.createWithVSC(networkuuid, true);
         VscModificationInfos modificationInfos = (VscModificationInfos) buildModification();
         modificationInfos.setAngleDroopActivePowerControl(new AttributeModification<>(true, OperationType.SET));
-        {
+        { //Test : p0 should be required if drop is changed
             modificationInfos.setDroop(new AttributeModification<>(10F, OperationType.SET));
             modificationInfos.setP0(null);
             VscModification vscModification = new VscModification(modificationInfos);
             Assert.assertThrows(NetworkModificationException.class, () -> vscModification.check(networkWitoutExt));
         }
+        { //Test : p0 should not be required if drop unchanged
+            modificationInfos.setDroop(null);
+            modificationInfos.setP0(new AttributeModification<>(10F, OperationType.SET));
+            VscModification vscModification = new VscModification(modificationInfos);
+            assertDoesNotThrow(() -> vscModification.check(networkWitoutExt));
+
+        }
+
     }
 
     @Override

--- a/src/test/java/org/gridsuite/modification/server/modifications/VscModificationTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/VscModificationTest.java
@@ -266,26 +266,15 @@ public class VscModificationTest extends AbstractNetworkModificationTest {
     @Test
     public void testActivateHvdcAngleDroopActivePowerControlWithoutP0() {
         var networkuuid = UUID.randomUUID();
-        Network networkWitoutExt = NetworkCreation.createWithVSC(networkuuid, false);
-        VscModificationInfos modificationInfos = (VscModificationInfos) buildModification();
-        modificationInfos.setAngleDroopActivePowerControl(new AttributeModification<>(true, OperationType.SET));
-        modificationInfos.setDroop(null);
-        modificationInfos.setP0(new AttributeModification<>(10F, OperationType.SET));
-        VscModification vscModification = new VscModification(modificationInfos);
-        Assert.assertThrows(NetworkModificationException.class, () -> vscModification.check(networkWitoutExt));
-    }
-
-    //Test : p0 sould be required if drop is enabled
-    @Test
-    public void testActivateHvdcAngleDroopActivePowerControlWithoutP02() { //To rename
-        var networkuuid = UUID.randomUUID();
         Network networkWitoutExt = NetworkCreation.createWithVSC(networkuuid, true);
         VscModificationInfos modificationInfos = (VscModificationInfos) buildModification();
         modificationInfos.setAngleDroopActivePowerControl(new AttributeModification<>(true, OperationType.SET));
-        modificationInfos.setDroop(null);
-        modificationInfos.setP0(new AttributeModification<>(10F, OperationType.SET));
-        VscModification vscModification = new VscModification(modificationInfos);
-        Assert.assertThrows(NetworkModificationException.class, () -> vscModification.check(networkWitoutExt));
+        {
+            modificationInfos.setDroop(new AttributeModification<>(10F, OperationType.SET));
+            modificationInfos.setP0(null);
+            VscModification vscModification = new VscModification(modificationInfos);
+            Assert.assertThrows(NetworkModificationException.class, () -> vscModification.check(networkWitoutExt));
+        }
     }
 
     @Override

--- a/src/test/java/org/gridsuite/modification/server/modifications/VscModificationTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/VscModificationTest.java
@@ -264,7 +264,7 @@ public class VscModificationTest extends AbstractNetworkModificationTest {
 
     //Test : p0 sould be required if drop is enabled
     @Test
-    public void testActivateHvdcAngleDroopActivePowerControlWithoutP0() {
+    public void testHvdcAngleDroopActivePowerControlWithoutP0() {
         var networkuuid = UUID.randomUUID();
         Network networkWitoutExt = NetworkCreation.createWithVSC(networkuuid, true);
         VscModificationInfos modificationInfos = (VscModificationInfos) buildModification();

--- a/src/test/java/org/gridsuite/modification/server/modifications/VscModificationTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/VscModificationTest.java
@@ -262,6 +262,32 @@ public class VscModificationTest extends AbstractNetworkModificationTest {
         Assert.assertTrue(activePowerControl.isEnabled());
     }
 
+    //Test : p0 sould be required if drop is enabled
+    @Test
+    public void testActivateHvdcAngleDroopActivePowerControlWithoutP0() {
+        var networkuuid = UUID.randomUUID();
+        Network networkWitoutExt = NetworkCreation.createWithVSC(networkuuid, false);
+        VscModificationInfos modificationInfos = (VscModificationInfos) buildModification();
+        modificationInfos.setAngleDroopActivePowerControl(new AttributeModification<>(true, OperationType.SET));
+        modificationInfos.setDroop(null);
+        modificationInfos.setP0(new AttributeModification<>(10F, OperationType.SET));
+        VscModification vscModification = new VscModification(modificationInfos);
+        Assert.assertThrows(NetworkModificationException.class, () -> vscModification.check(networkWitoutExt));
+    }
+
+    //Test : p0 sould be required if drop is enabled
+    @Test
+    public void testActivateHvdcAngleDroopActivePowerControlWithoutP02() { //To rename
+        var networkuuid = UUID.randomUUID();
+        Network networkWitoutExt = NetworkCreation.createWithVSC(networkuuid, true);
+        VscModificationInfos modificationInfos = (VscModificationInfos) buildModification();
+        modificationInfos.setAngleDroopActivePowerControl(new AttributeModification<>(true, OperationType.SET));
+        modificationInfos.setDroop(null);
+        modificationInfos.setP0(new AttributeModification<>(10F, OperationType.SET));
+        VscModification vscModification = new VscModification(modificationInfos);
+        Assert.assertThrows(NetworkModificationException.class, () -> vscModification.check(networkWitoutExt));
+    }
+
     @Override
     @SneakyThrows
     protected void testUpdateModificationMessage(ModificationInfos modificationInfos) {


### PR DESCRIPTION
This pull request fixes an issue with modifying converter stations in the network. Previously, the modification process was retrieving the converter stations from user inputs leading to errors.  
this fix retrieve the converter stations from the network wich is more reliable 

see related pull request [gridstudy-app](https://github.com/gridsuite/gridstudy-app/pull/2090)