### PR TITLE
Check null values for droop and P0 (2e patch)

### DIFF
--- a/src/main/java/org/gridsuite/modification/server/modifications/ModificationUtils.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/ModificationUtils.java
@@ -1307,30 +1307,20 @@ public final class ModificationUtils {
         }
     }
 
-    public static void checkHvdcDroopInfos(boolean isPresentAngleDroopActivePowerControl, boolean isPresentDroop, boolean isPresentP0) {
+    public static void checkHvdcDroop(boolean isPresentAngleDroopActivePowerControl, boolean isPresentDroop, boolean isPresentP0) {
         // all fields should be filled => OK extension will be created
-        if (isPresentAngleDroopActivePowerControl &&
-            isPresentDroop &&
-            isPresentP0) {
+        if (isPresentAngleDroopActivePowerControl && isPresentDroop && isPresentP0) {
             return;
         }
-
         // at least one field is filled but not for others => NOT OK
-        if (isPresentAngleDroopActivePowerControl ||
-            isPresentDroop ||
-            isPresentP0) {
+        if (isPresentAngleDroopActivePowerControl || isPresentDroop || isPresentP0) {
             throw new NetworkModificationException(WRONG_HVDC_ANGLE_DROOP_ACTIVE_POWER_CONTROL, ACTIVE_POWER_CONTROL_DROOP_P0_REQUIRED_ERROR_MSG);
         }
-
         // all fields are not filled => OK extension will not be created
     }
 
-    public static boolean shouldCreateHvdcDroopActivePowerControlExtension(boolean isPresentAngleDroopActivePowerControl,
-                                                                           boolean isPresentDroop,
-                                                                           boolean isPresentP0) {
-        return isPresentAngleDroopActivePowerControl &&
-               isPresentDroop &&
-               isPresentP0;
+    public static boolean shouldCreateHvdcDroopActivePowerControlExtension(boolean isPresentAngleDroopActivePowerControl, boolean isPresentDroop, boolean isPresentP0) {
+        return isPresentAngleDroopActivePowerControl && isPresentDroop && isPresentP0;
     }
 }
 

--- a/src/main/java/org/gridsuite/modification/server/modifications/ModificationUtils.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/ModificationUtils.java
@@ -55,6 +55,8 @@ public final class ModificationUtils {
     public static final String CONNECTION_DIRECTION_FIELD_NAME = "Connection direction";
     public static final String CONNECTION_POSITION_FIELD_NAME = "Connection position";
 
+    public static final String ACTIVE_POWER_CONTROL_DROOP_P0_REQUIRED_ERROR_MSG = "Angle droop active power control, Droop and P0 must be provided together";
+
     private ModificationUtils() {
     }
 
@@ -1303,6 +1305,32 @@ public final class ModificationUtils {
         if (child.getChildren() != null) {
             child.getChildren().forEach(grandChild -> insertReportNode(insertedChild, grandChild));
         }
+    }
+
+    public static void checkHvdcDroopInfos(boolean isPresentAngleDroopActivePowerControl, boolean isPresentDroop, boolean isPresentP0) {
+        // all fields should be filled => OK extension will be created
+        if (isPresentAngleDroopActivePowerControl &&
+            isPresentDroop &&
+            isPresentP0) {
+            return;
+        }
+
+        // at least one field is filled but not for others => NOT OK
+        if (isPresentAngleDroopActivePowerControl ||
+            isPresentDroop ||
+            isPresentP0) {
+            throw new NetworkModificationException(WRONG_HVDC_ANGLE_DROOP_ACTIVE_POWER_CONTROL, ACTIVE_POWER_CONTROL_DROOP_P0_REQUIRED_ERROR_MSG);
+        }
+
+        // all fields are not filled => OK extension will not be created
+    }
+
+    public static boolean shouldCreateHvdcDroopActivePowerControlExtension(boolean isPresentAngleDroopActivePowerControl,
+                                                                           boolean isPresentDroop,
+                                                                           boolean isPresentP0) {
+        return isPresentAngleDroopActivePowerControl &&
+               isPresentDroop &&
+               isPresentP0;
     }
 }
 

--- a/src/main/java/org/gridsuite/modification/server/modifications/ModificationUtils.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/ModificationUtils.java
@@ -1304,6 +1304,5 @@ public final class ModificationUtils {
             child.getChildren().forEach(grandChild -> insertReportNode(insertedChild, grandChild));
         }
     }
-
 }
 

--- a/src/main/java/org/gridsuite/modification/server/modifications/ModificationUtils.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/ModificationUtils.java
@@ -55,8 +55,6 @@ public final class ModificationUtils {
     public static final String CONNECTION_DIRECTION_FIELD_NAME = "Connection direction";
     public static final String CONNECTION_POSITION_FIELD_NAME = "Connection position";
 
-    public static final String ACTIVE_POWER_CONTROL_DROOP_P0_REQUIRED_ERROR_MSG = "Angle droop active power control, Droop and P0 must be provided together";
-
     private ModificationUtils() {
     }
 
@@ -1307,20 +1305,5 @@ public final class ModificationUtils {
         }
     }
 
-    public static void checkHvdcDroop(boolean isPresentAngleDroopActivePowerControl, boolean isPresentDroop, boolean isPresentP0) {
-        // all fields should be filled => OK extension will be created
-        if (isPresentAngleDroopActivePowerControl && isPresentDroop && isPresentP0) {
-            return;
-        }
-        // at least one field is filled but not for others => NOT OK
-        if (isPresentAngleDroopActivePowerControl || isPresentDroop || isPresentP0) {
-            throw new NetworkModificationException(WRONG_HVDC_ANGLE_DROOP_ACTIVE_POWER_CONTROL, ACTIVE_POWER_CONTROL_DROOP_P0_REQUIRED_ERROR_MSG);
-        }
-        // all fields are not filled => OK extension will not be created
-    }
-
-    public static boolean shouldCreateHvdcDroopActivePowerControlExtension(boolean isPresentAngleDroopActivePowerControl, boolean isPresentDroop, boolean isPresentP0) {
-        return isPresentAngleDroopActivePowerControl && isPresentDroop && isPresentP0;
-    }
 }
 

--- a/src/main/java/org/gridsuite/modification/server/modifications/VscCreation.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/VscCreation.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 
 import static org.gridsuite.modification.server.NetworkModificationException.Type.*;
-import static org.gridsuite.modification.server.modifications.VscModification.DROOP_ACTIVE_POWER_CONTROL_P0_DROOP_REQUIRED_ERROR_MSG;
 
 /**
  * @author Seddik Yengui <seddik.yengui at rte-france.com>
@@ -33,6 +32,7 @@ public class VscCreation extends AbstractModification {
 
     public static final String VSC_SETPOINTS = "vscSetPoints";
     public static final String VSC_CHARACTERISTICS = "vscCharacteristics";
+    public static final String DROOP_P0_REQUIRED_ERROR_MSG = "Droop and P0 are both required when angle droop active power control is activated";
 
     private final VscCreationInfos modificationInfos;
 
@@ -59,8 +59,7 @@ public class VscCreation extends AbstractModification {
 
         // enable the extension => should verify whether all fields have been filled
         if (modificationInfos.getDroop() == null || modificationInfos.getP0() == null) {
-            throw new NetworkModificationException(WRONG_HVDC_ANGLE_DROOP_ACTIVE_POWER_CONTROL,
-                    String.format(DROOP_ACTIVE_POWER_CONTROL_P0_DROOP_REQUIRED_ERROR_MSG));
+            throw new NetworkModificationException(WRONG_HVDC_ANGLE_DROOP_ACTIVE_POWER_CONTROL, DROOP_P0_REQUIRED_ERROR_MSG);
         }
     }
 

--- a/src/main/java/org/gridsuite/modification/server/modifications/VscCreation.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/VscCreation.java
@@ -24,8 +24,8 @@ import java.util.Map;
 
 import static org.gridsuite.modification.server.NetworkModificationException.Type.CREATE_VSC_ERROR;
 import static org.gridsuite.modification.server.NetworkModificationException.Type.HVDC_LINE_ALREADY_EXISTS;
-import static org.gridsuite.modification.server.modifications.ModificationUtils.checkHvdcDroop;
-import static org.gridsuite.modification.server.modifications.ModificationUtils.shouldCreateHvdcDroopActivePowerControlExtension;
+import static org.gridsuite.modification.server.modifications.VscModification.checkHvdcDroop;
+import static org.gridsuite.modification.server.modifications.VscModification.shouldCreateHvdcDroopActivePowerControlExtension;
 
 /**
  * @author Seddik Yengui <seddik.yengui at rte-france.com>

--- a/src/main/java/org/gridsuite/modification/server/modifications/VscCreation.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/VscCreation.java
@@ -53,6 +53,10 @@ public class VscCreation extends AbstractModification {
     }
 
     private void checkDroop() {
+        // particular case, not enabling and others fields are not provided => OK extension will not be created
+        if (Boolean.FALSE.equals(modificationInfos.getAngleDroopActivePowerControl()) && modificationInfos.getDroop() == null && modificationInfos.getP0() == null) {
+            return;
+        }
         VscModification.checkDroop(modificationInfos.getAngleDroopActivePowerControl() != null, modificationInfos.getDroop() != null, modificationInfos.getP0() != null);
     }
 

--- a/src/main/java/org/gridsuite/modification/server/modifications/VscCreation.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/VscCreation.java
@@ -24,7 +24,7 @@ import java.util.Map;
 
 import static org.gridsuite.modification.server.NetworkModificationException.Type.CREATE_VSC_ERROR;
 import static org.gridsuite.modification.server.NetworkModificationException.Type.HVDC_LINE_ALREADY_EXISTS;
-import static org.gridsuite.modification.server.modifications.ModificationUtils.checkHvdcDroopInfos;
+import static org.gridsuite.modification.server.modifications.ModificationUtils.checkHvdcDroop;
 import static org.gridsuite.modification.server.modifications.ModificationUtils.shouldCreateHvdcDroopActivePowerControlExtension;
 
 /**
@@ -54,10 +54,7 @@ public class VscCreation extends AbstractModification {
     }
 
     private void checkDroop() {
-        checkHvdcDroopInfos(
-                modificationInfos.getAngleDroopActivePowerControl() != null,
-                modificationInfos.getDroop() != null,
-                modificationInfos.getP0() != null);
+        checkHvdcDroop(modificationInfos.getAngleDroopActivePowerControl() != null, modificationInfos.getDroop() != null, modificationInfos.getP0() != null);
     }
 
     private void checkConverterStation(Network network,
@@ -131,9 +128,7 @@ public class VscCreation extends AbstractModification {
 
     private boolean shouldCreateDroopActivePowerControlExtension() {
         return shouldCreateHvdcDroopActivePowerControlExtension(
-                modificationInfos.getAngleDroopActivePowerControl() != null,
-                modificationInfos.getDroop() != null,
-                modificationInfos.getP0() != null);
+            modificationInfos.getAngleDroopActivePowerControl() != null, modificationInfos.getDroop() != null, modificationInfos.getP0() != null);
     }
 
     private void reportHvdcLineInfos(ReportNode subReportNode) {

--- a/src/main/java/org/gridsuite/modification/server/modifications/VscCreation.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/VscCreation.java
@@ -24,7 +24,6 @@ import java.util.Map;
 
 import static org.gridsuite.modification.server.NetworkModificationException.Type.CREATE_VSC_ERROR;
 import static org.gridsuite.modification.server.NetworkModificationException.Type.HVDC_LINE_ALREADY_EXISTS;
-import static org.gridsuite.modification.server.modifications.VscModification.checkHvdcDroop;
 import static org.gridsuite.modification.server.modifications.VscModification.shouldCreateHvdcDroopActivePowerControlExtension;
 
 /**
@@ -54,7 +53,7 @@ public class VscCreation extends AbstractModification {
     }
 
     private void checkDroop() {
-        checkHvdcDroop(modificationInfos.getAngleDroopActivePowerControl() != null, modificationInfos.getDroop() != null, modificationInfos.getP0() != null);
+        VscModification.checkDroop(modificationInfos.getAngleDroopActivePowerControl() != null, modificationInfos.getDroop() != null, modificationInfos.getP0() != null);
     }
 
     private void checkConverterStation(Network network,

--- a/src/main/java/org/gridsuite/modification/server/modifications/VscCreation.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/VscCreation.java
@@ -62,11 +62,11 @@ public class VscCreation extends AbstractModification {
         if (Boolean.FALSE.equals(modificationInfos.getAngleDroopActivePowerControl()) && !isPresentDroop && !isPresentP0) {
             return;
         }
-        // at least one field is provided but not for others => NOT OK
+        // at least one field is provided but not for the others => NOT OK
         if (isPresentAngleDroopActivePowerControl || isPresentDroop || isPresentP0) {
             throw new NetworkModificationException(WRONG_HVDC_ANGLE_DROOP_ACTIVE_POWER_CONTROL, VscModification.ACTIVE_POWER_CONTROL_DROOP_P0_REQUIRED_ERROR_MSG);
         }
-        // otherwise, i.e. all fields are not provided => OK extension will not be created
+        // otherwise, i.e. none of the fields is not provided => OK extension will not be created
     }
 
     private void checkConverterStation(Network network,

--- a/src/main/java/org/gridsuite/modification/server/modifications/VscModification.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/VscModification.java
@@ -43,19 +43,7 @@ public class VscModification extends AbstractModification {
         this.modificationInfos = vscModificationInfos;
     }
 
-    public static void checkDroop(boolean isPresentAngleDroopActivePowerControl, boolean isPresentDroop, boolean isPresentP0) {
-        // all fields should be provided => OK extension will be created
-        if (isPresentAngleDroopActivePowerControl && isPresentDroop && isPresentP0) {
-            return;
-        }
-        // at least one field is provided but not for others => NOT OK
-        // all fields are not provided => OK extension will not be created
-        if (isPresentAngleDroopActivePowerControl || isPresentDroop || isPresentP0) {
-            throw new NetworkModificationException(WRONG_HVDC_ANGLE_DROOP_ACTIVE_POWER_CONTROL, ACTIVE_POWER_CONTROL_DROOP_P0_REQUIRED_ERROR_MSG);
-        }
-    }
-
-    public static boolean shouldCreateHvdcDroopActivePowerControlExtension(boolean isPresentAngleDroopActivePowerControl, boolean isPresentDroop, boolean isPresentP0) {
+    public static boolean shouldCreateDroopActivePowerControlExtension(boolean isPresentAngleDroopActivePowerControl, boolean isPresentDroop, boolean isPresentP0) {
         return isPresentAngleDroopActivePowerControl && isPresentDroop && isPresentP0;
     }
 
@@ -89,7 +77,18 @@ public class VscModification extends AbstractModification {
         }
 
         //--- the extension doesn't exist yet ---//
-        checkDroop(modificationInfos.getAngleDroopActivePowerControl() != null, modificationInfos.getDroop() != null, modificationInfos.getP0() != null);
+        boolean isPresentAngleDroopActivePowerControl = modificationInfos.getAngleDroopActivePowerControl() != null;
+        boolean isPresentDroop = modificationInfos.getDroop() != null;
+        boolean isPresentP0 = modificationInfos.getP0() != null;
+        // all fields are provided => OK extension will be created
+        if (isPresentAngleDroopActivePowerControl && isPresentDroop && isPresentP0) {
+            return;
+        }
+        // at least one field is provided but not for others => NOT OK
+        if (isPresentAngleDroopActivePowerControl || isPresentDroop || isPresentP0) {
+            throw new NetworkModificationException(WRONG_HVDC_ANGLE_DROOP_ACTIVE_POWER_CONTROL, ACTIVE_POWER_CONTROL_DROOP_P0_REQUIRED_ERROR_MSG);
+        }
+        // otherwise, i.e. all fields are not provided => OK extension will not be created
     }
 
     @Override
@@ -242,7 +241,7 @@ public class VscModification extends AbstractModification {
     }
 
     private boolean shouldCreateDroopActivePowerControlExtension() {
-        return shouldCreateHvdcDroopActivePowerControlExtension(
+        return shouldCreateDroopActivePowerControlExtension(
             modificationInfos.getAngleDroopActivePowerControl() != null, modificationInfos.getDroop() != null, modificationInfos.getP0() != null);
     }
 

--- a/src/main/java/org/gridsuite/modification/server/modifications/VscModification.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/VscModification.java
@@ -21,7 +21,8 @@ import org.gridsuite.modification.server.dto.VscModificationInfos;
 import javax.annotation.Nonnull;
 import java.util.*;
 
-import static org.gridsuite.modification.server.NetworkModificationException.Type.*;
+import static org.gridsuite.modification.server.NetworkModificationException.Type.MODIFY_VSC_ERROR;
+import static org.gridsuite.modification.server.NetworkModificationException.Type.WRONG_HVDC_ANGLE_DROOP_ACTIVE_POWER_CONTROL;
 import static org.gridsuite.modification.server.modifications.VscCreation.VSC_CHARACTERISTICS;
 import static org.gridsuite.modification.server.modifications.VscCreation.VSC_SETPOINTS;
 
@@ -69,7 +70,7 @@ public class VscModification extends AbstractModification {
         if (modificationInfos == null
                 || modificationInfos.getConverterStation1() == null
                 || modificationInfos.getConverterStation2() == null) {
-            throw new NetworkModificationException(MODIFY_BATTERY_ERROR, "Missing required attributes to modify the equipment");
+            throw new NetworkModificationException(MODIFY_VSC_ERROR, "Missing required attributes to modify the equipment");
         }
         HvdcLine hvdcLine = ModificationUtils.getInstance().getHvdcLine(network, modificationInfos.getEquipmentId());
 

--- a/src/main/java/org/gridsuite/modification/server/modifications/VscModification.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/VscModification.java
@@ -21,10 +21,7 @@ import org.gridsuite.modification.server.dto.VscModificationInfos;
 import javax.annotation.Nonnull;
 import java.util.*;
 
-import static org.gridsuite.modification.server.NetworkModificationException.Type.MODIFY_BATTERY_ERROR;
-import static org.gridsuite.modification.server.NetworkModificationException.Type.MODIFY_VSC_ERROR;
-import static org.gridsuite.modification.server.modifications.ModificationUtils.checkHvdcDroop;
-import static org.gridsuite.modification.server.modifications.ModificationUtils.shouldCreateHvdcDroopActivePowerControlExtension;
+import static org.gridsuite.modification.server.NetworkModificationException.Type.*;
 import static org.gridsuite.modification.server.modifications.VscCreation.VSC_CHARACTERISTICS;
 import static org.gridsuite.modification.server.modifications.VscCreation.VSC_SETPOINTS;
 
@@ -37,11 +34,28 @@ public class VscModification extends AbstractModification {
     public static final String ANGLE_DROOP_ACTIVE_POWER_CONTROL_FIELD = "AngleDroopActivePowerControl";
     public static final String DROOP_FIELD = "Droop";
     public static final String P0_FIELD = "P0";
+    public static final String ACTIVE_POWER_CONTROL_DROOP_P0_REQUIRED_ERROR_MSG = "Angle droop active power control, Droop and P0 must be provided together";
 
     private final VscModificationInfos modificationInfos;
 
     public VscModification(VscModificationInfos vscModificationInfos) {
         this.modificationInfos = vscModificationInfos;
+    }
+
+    public static void checkHvdcDroop(boolean isPresentAngleDroopActivePowerControl, boolean isPresentDroop, boolean isPresentP0) {
+        // all fields should be filled => OK extension will be created
+        if (isPresentAngleDroopActivePowerControl && isPresentDroop && isPresentP0) {
+            return;
+        }
+        // at least one field is filled but not for others => NOT OK
+        if (isPresentAngleDroopActivePowerControl || isPresentDroop || isPresentP0) {
+            throw new NetworkModificationException(WRONG_HVDC_ANGLE_DROOP_ACTIVE_POWER_CONTROL, ACTIVE_POWER_CONTROL_DROOP_P0_REQUIRED_ERROR_MSG);
+        }
+        // all fields are not filled => OK extension will not be created
+    }
+
+    public static boolean shouldCreateHvdcDroopActivePowerControlExtension(boolean isPresentAngleDroopActivePowerControl, boolean isPresentDroop, boolean isPresentP0) {
+        return isPresentAngleDroopActivePowerControl && isPresentDroop && isPresentP0;
     }
 
     protected void checkConverterStation(@Nonnull ConverterStationModificationInfos converterStationModificationInfos, @Nonnull VscConverterStation vscConverterStation) {

--- a/src/main/java/org/gridsuite/modification/server/modifications/VscModification.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/VscModification.java
@@ -34,8 +34,7 @@ public class VscModification extends AbstractModification {
     public static final String ANGLE_DROOP_ACTIVE_POWER_CONTROL_FIELD = "AngleDroopActivePowerControl";
     public static final String DROOP_FIELD = "Droop";
     public static final String P0_FIELD = "P0";
-    public static final String DROOP_ACTIVE_POWER_CONTROL_P0_DROOP_REQUIRED_ERROR_MSG = "Both Droop and P0 are required when angle droop active power control is activated";
-    public static final String DROOP_ACTIVE_POWER_CONTROL_P0_REQUIRED_ERROR_MSG = "P0 is required when Droop is provided";
+    public static final String ACTIVE_POWER_CONTROL_DROOP_P0_REQUIRED_ERROR_MSG = "Angle droop active power control, Droop and P0 must be provided together";
 
     private final VscModificationInfos modificationInfos;
 
@@ -66,29 +65,29 @@ public class VscModification extends AbstractModification {
     }
 
     private void checkDroopModification(HvdcLine hvdcLine) {
-        // the extension already exists
+        //--- the extension already exists ---//
         HvdcAngleDroopActivePowerControl hvdcAngleDroopActivePowerControl = hvdcLine.getExtension(HvdcAngleDroopActivePowerControl.class);
         if (hvdcAngleDroopActivePowerControl != null) {
-            // if droop is set p0 should be also
-            if (modificationInfos.getDroop() != null && modificationInfos.getP0() == null) {
-                throw new NetworkModificationException(WRONG_HVDC_ANGLE_DROOP_ACTIVE_POWER_CONTROL,
-                        String.format(DROOP_ACTIVE_POWER_CONTROL_P0_REQUIRED_ERROR_MSG));
-            }
             return;
         }
 
-        // the extension doesn't exist yet and the modification wants to enable the extension =>
-        // should verify whether all fields have been filled
-        boolean isEnabledAngleDroopActivePowerControl = modificationInfos.getAngleDroopActivePowerControl() != null
-            && Boolean.TRUE.equals(modificationInfos.getAngleDroopActivePowerControl().getValue());
-        if (!isEnabledAngleDroopActivePowerControl) {
+        //--- the extension doesn't exist yet ---//
+        // all fields should be filled => OK
+        if (modificationInfos.getAngleDroopActivePowerControl() != null &&
+            modificationInfos.getDroop() != null &&
+            modificationInfos.getP0() != null) {
             return;
         }
 
-        if (modificationInfos.getDroop() == null || modificationInfos.getP0() == null) {
+        // at least one field is filled but not for others => NOT OK
+        if (modificationInfos.getAngleDroopActivePowerControl() != null ||
+            modificationInfos.getDroop() != null ||
+            modificationInfos.getP0() != null) {
             throw new NetworkModificationException(WRONG_HVDC_ANGLE_DROOP_ACTIVE_POWER_CONTROL,
-                    String.format(DROOP_ACTIVE_POWER_CONTROL_P0_DROOP_REQUIRED_ERROR_MSG));
+                    ACTIVE_POWER_CONTROL_DROOP_P0_REQUIRED_ERROR_MSG);
         }
+
+        // all fields are not filled => OK => do nothing
     }
 
     @Override

--- a/src/main/java/org/gridsuite/modification/server/modifications/VscModification.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/VscModification.java
@@ -23,7 +23,7 @@ import java.util.*;
 
 import static org.gridsuite.modification.server.NetworkModificationException.Type.MODIFY_BATTERY_ERROR;
 import static org.gridsuite.modification.server.NetworkModificationException.Type.MODIFY_VSC_ERROR;
-import static org.gridsuite.modification.server.modifications.ModificationUtils.checkHvdcDroopInfos;
+import static org.gridsuite.modification.server.modifications.ModificationUtils.checkHvdcDroop;
 import static org.gridsuite.modification.server.modifications.ModificationUtils.shouldCreateHvdcDroopActivePowerControlExtension;
 import static org.gridsuite.modification.server.modifications.VscCreation.VSC_CHARACTERISTICS;
 import static org.gridsuite.modification.server.modifications.VscCreation.VSC_SETPOINTS;
@@ -74,10 +74,7 @@ public class VscModification extends AbstractModification {
         }
 
         //--- the extension doesn't exist yet ---//
-        checkHvdcDroopInfos(
-                modificationInfos.getAngleDroopActivePowerControl() != null,
-                modificationInfos.getDroop() != null,
-                modificationInfos.getP0() != null);
+        checkHvdcDroop(modificationInfos.getAngleDroopActivePowerControl() != null, modificationInfos.getDroop() != null, modificationInfos.getP0() != null);
     }
 
     @Override
@@ -231,9 +228,7 @@ public class VscModification extends AbstractModification {
 
     private boolean shouldCreateDroopActivePowerControlExtension() {
         return shouldCreateHvdcDroopActivePowerControlExtension(
-                modificationInfos.getAngleDroopActivePowerControl() != null,
-                modificationInfos.getDroop() != null,
-                modificationInfos.getP0() != null);
+            modificationInfos.getAngleDroopActivePowerControl() != null, modificationInfos.getDroop() != null, modificationInfos.getP0() != null);
     }
 
     private List<ReportNode> hvdcAngleDroopActivePowerControlAdder(HvdcLine hvdcLine) {

--- a/src/main/java/org/gridsuite/modification/server/modifications/VscModification.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/VscModification.java
@@ -84,11 +84,11 @@ public class VscModification extends AbstractModification {
         if (isPresentAngleDroopActivePowerControl && isPresentDroop && isPresentP0) {
             return;
         }
-        // at least one field is provided but not for others => NOT OK
+        // at least one field is provided but not for the others => NOT OK
         if (isPresentAngleDroopActivePowerControl || isPresentDroop || isPresentP0) {
             throw new NetworkModificationException(WRONG_HVDC_ANGLE_DROOP_ACTIVE_POWER_CONTROL, ACTIVE_POWER_CONTROL_DROOP_P0_REQUIRED_ERROR_MSG);
         }
-        // otherwise, i.e. all fields are not provided => OK extension will not be created
+        // otherwise, i.e. none of the fields is provided => OK extension will not be created
     }
 
     @Override

--- a/src/main/java/org/gridsuite/modification/server/modifications/VscModification.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/VscModification.java
@@ -35,7 +35,7 @@ public class VscModification extends AbstractModification {
     public static final String ANGLE_DROOP_ACTIVE_POWER_CONTROL_FIELD = "AngleDroopActivePowerControl";
     public static final String DROOP_FIELD = "Droop";
     public static final String P0_FIELD = "P0";
-    public static final String ACTIVE_POWER_CONTROL_DROOP_P0_REQUIRED_ERROR_MSG = "Angle droop active power control, Droop and P0 must be provided together";
+    public static final String ACTIVE_POWER_CONTROL_DROOP_P0_REQUIRED_ERROR_MSG = "Angle droop active power control, Droop and P0 must be all provided or none";
 
     private final VscModificationInfos modificationInfos;
 
@@ -43,16 +43,16 @@ public class VscModification extends AbstractModification {
         this.modificationInfos = vscModificationInfos;
     }
 
-    public static void checkHvdcDroop(boolean isPresentAngleDroopActivePowerControl, boolean isPresentDroop, boolean isPresentP0) {
-        // all fields should be filled => OK extension will be created
+    public static void checkDroop(boolean isPresentAngleDroopActivePowerControl, boolean isPresentDroop, boolean isPresentP0) {
+        // all fields should be provided => OK extension will be created
         if (isPresentAngleDroopActivePowerControl && isPresentDroop && isPresentP0) {
             return;
         }
-        // at least one field is filled but not for others => NOT OK
+        // at least one field is provided but not for others => NOT OK
+        // all fields are not provided => OK extension will not be created
         if (isPresentAngleDroopActivePowerControl || isPresentDroop || isPresentP0) {
             throw new NetworkModificationException(WRONG_HVDC_ANGLE_DROOP_ACTIVE_POWER_CONTROL, ACTIVE_POWER_CONTROL_DROOP_P0_REQUIRED_ERROR_MSG);
         }
-        // all fields are not filled => OK extension will not be created
     }
 
     public static boolean shouldCreateHvdcDroopActivePowerControlExtension(boolean isPresentAngleDroopActivePowerControl, boolean isPresentDroop, boolean isPresentP0) {
@@ -89,7 +89,7 @@ public class VscModification extends AbstractModification {
         }
 
         //--- the extension doesn't exist yet ---//
-        checkHvdcDroop(modificationInfos.getAngleDroopActivePowerControl() != null, modificationInfos.getDroop() != null, modificationInfos.getP0() != null);
+        checkDroop(modificationInfos.getAngleDroopActivePowerControl() != null, modificationInfos.getDroop() != null, modificationInfos.getP0() != null);
     }
 
     @Override

--- a/src/test/java/org/gridsuite/modification/server/modifications/VscCreationTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/VscCreationTest.java
@@ -26,7 +26,7 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.gridsuite.modification.server.NetworkModificationException.Type.*;
-import static org.gridsuite.modification.server.modifications.VscCreation.DROOP_P0_REQUIRED_ERROR_MSG;
+import static org.gridsuite.modification.server.modifications.ModificationUtils.ACTIVE_POWER_CONTROL_DROOP_P0_REQUIRED_ERROR_MSG;
 import static org.gridsuite.modification.server.utils.TestUtils.assertLogMessage;
 import static org.junit.Assert.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -313,7 +313,10 @@ public class VscCreationTest extends AbstractNetworkModificationTest {
         HvdcLine hvdcLine = getNetwork().getHvdcLine("vsc1");
         assertThat(hvdcLine).isNotNull();
         HvdcAngleDroopActivePowerControl activePowerControl = hvdcLine.getExtension(HvdcAngleDroopActivePowerControl.class);
-        assertThat(activePowerControl).isNull();
+        assertThat(activePowerControl).isNotNull();
+        assertThat(activePowerControl.isEnabled()).isFalse();
+        assertThat(activePowerControl.getDroop()).isEqualTo(1F);
+        assertThat(activePowerControl.getP0()).isEqualTo(5F);
     }
 
     @Test
@@ -327,7 +330,7 @@ public class VscCreationTest extends AbstractNetworkModificationTest {
         mockMvc.perform(post(getNetworkModificationUri()).content(vscCreationInfosJson).contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
         assertLogMessage(new NetworkModificationException(WRONG_HVDC_ANGLE_DROOP_ACTIVE_POWER_CONTROL,
-                        String.format(DROOP_P0_REQUIRED_ERROR_MSG)).getMessage(),
+                        ACTIVE_POWER_CONTROL_DROOP_P0_REQUIRED_ERROR_MSG).getMessage(),
                 vscCreationInfos.getErrorType().name(), reportService);
     }
 }

--- a/src/test/java/org/gridsuite/modification/server/modifications/VscCreationTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/VscCreationTest.java
@@ -308,7 +308,6 @@ public class VscCreationTest extends AbstractNetworkModificationTest {
         String vscCreationInfosJson = mapper.writeValueAsString(vscCreationInfos);
         mockMvc.perform(post(getNetworkModificationUri()).content(vscCreationInfosJson).contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
-        assertThat(getNetwork().getHvdcLine("vsc1")).isNotNull();
         HvdcLine hvdcLine = getNetwork().getHvdcLine("vsc1");
         assertThat(hvdcLine).isNotNull();
         HvdcAngleDroopActivePowerControl activePowerControlExt = hvdcLine.getExtension(HvdcAngleDroopActivePowerControl.class);
@@ -327,7 +326,6 @@ public class VscCreationTest extends AbstractNetworkModificationTest {
         String vscCreationInfosJson = mapper.writeValueAsString(vscCreationInfos);
         mockMvc.perform(post(getNetworkModificationUri()).content(vscCreationInfosJson).contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
-        assertThat(getNetwork().getHvdcLine("vsc1")).isNotNull();
         HvdcLine hvdcLine = getNetwork().getHvdcLine("vsc1");
         assertThat(hvdcLine).isNotNull();
         HvdcAngleDroopActivePowerControl activePowerControlExt = hvdcLine.getExtension(HvdcAngleDroopActivePowerControl.class);

--- a/src/test/java/org/gridsuite/modification/server/modifications/VscCreationTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/VscCreationTest.java
@@ -302,8 +302,7 @@ public class VscCreationTest extends AbstractNetworkModificationTest {
     }
 
     @Test
-    public void testCreateWithoutEnablingDroopPowerControl() throws Exception {
-        // create without enabling droop power control
+    public void testCreateAngleDroopPowerControlWithoutEnabling() throws Exception {
         VscCreationInfos vscCreationInfos = (VscCreationInfos) buildModification();
         vscCreationInfos.setAngleDroopActivePowerControl(false);
         String vscCreationInfosJson = mapper.writeValueAsString(vscCreationInfos);
@@ -312,20 +311,46 @@ public class VscCreationTest extends AbstractNetworkModificationTest {
         assertThat(getNetwork().getHvdcLine("vsc1")).isNotNull();
         HvdcLine hvdcLine = getNetwork().getHvdcLine("vsc1");
         assertThat(hvdcLine).isNotNull();
-        HvdcAngleDroopActivePowerControl activePowerControl = hvdcLine.getExtension(HvdcAngleDroopActivePowerControl.class);
-        assertThat(activePowerControl).isNotNull();
-        assertThat(activePowerControl.isEnabled()).isFalse();
-        assertThat(activePowerControl.getDroop()).isEqualTo(1F);
-        assertThat(activePowerControl.getP0()).isEqualTo(5F);
+        HvdcAngleDroopActivePowerControl activePowerControlExt = hvdcLine.getExtension(HvdcAngleDroopActivePowerControl.class);
+        assertThat(activePowerControlExt).isNotNull();
+        assertThat(activePowerControlExt.isEnabled()).isFalse();
+        assertThat(activePowerControlExt.getDroop()).isEqualTo(1F);
+        assertThat(activePowerControlExt.getP0()).isEqualTo(5F);
     }
 
     @Test
-    public void testCreateWithEnablingDroopPowerControl() throws Exception {
-        // create with enabling droop power control but not provide Droop and P0
+    public void testAngleDroopPowerControlWithAbsentInfos() throws Exception {
+        boolean[][] droopInfosIsPresentData = {
+            {true, false, false},
+            {true, true, false},
+            {true, false, true},
+            {false, true, false},
+            {false, true, true},
+            {false, false, true},
+        };
+
+        for (boolean[] droopInfoIsPresent : droopInfosIsPresentData) {
+            VscCreationInfos vscCreationInfos = buildModificationWithDroopAbsentInfos(droopInfoIsPresent[0], droopInfoIsPresent[1], droopInfoIsPresent[2]);
+            checkDroopWithAbsentInfos(vscCreationInfos);
+        }
+    }
+
+    private VscCreationInfos buildModificationWithDroopAbsentInfos(boolean isPresentAngleDroopActivePowerControl, boolean isPresentDroop, boolean isPresentP0) {
         VscCreationInfos vscCreationInfos = (VscCreationInfos) buildModification();
-        vscCreationInfos.setAngleDroopActivePowerControl(true);
-        vscCreationInfos.setDroop(null);
-        vscCreationInfos.setP0(null);
+        // reset null depending to test arguments
+        if (!isPresentAngleDroopActivePowerControl) {
+            vscCreationInfos.setAngleDroopActivePowerControl(null);
+        }
+        if (!isPresentDroop) {
+            vscCreationInfos.setDroop(null);
+        }
+        if (!isPresentP0) {
+            vscCreationInfos.setP0(null);
+        }
+        return vscCreationInfos;
+    }
+
+    private void checkDroopWithAbsentInfos(VscCreationInfos vscCreationInfos) throws Exception {
         String vscCreationInfosJson = mapper.writeValueAsString(vscCreationInfos);
         mockMvc.perform(post(getNetworkModificationUri()).content(vscCreationInfosJson).contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());

--- a/src/test/java/org/gridsuite/modification/server/modifications/VscCreationTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/VscCreationTest.java
@@ -26,7 +26,7 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.gridsuite.modification.server.NetworkModificationException.Type.*;
-import static org.gridsuite.modification.server.modifications.VscModification.DROOP_ACTIVE_POWER_CONTROL_P0_DROOP_REQUIRED_ERROR_MSG;
+import static org.gridsuite.modification.server.modifications.VscCreation.DROOP_P0_REQUIRED_ERROR_MSG;
 import static org.gridsuite.modification.server.utils.TestUtils.assertLogMessage;
 import static org.junit.Assert.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -327,7 +327,7 @@ public class VscCreationTest extends AbstractNetworkModificationTest {
         mockMvc.perform(post(getNetworkModificationUri()).content(vscCreationInfosJson).contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
         assertLogMessage(new NetworkModificationException(WRONG_HVDC_ANGLE_DROOP_ACTIVE_POWER_CONTROL,
-                        String.format(DROOP_ACTIVE_POWER_CONTROL_P0_DROOP_REQUIRED_ERROR_MSG)).getMessage(),
+                        String.format(DROOP_P0_REQUIRED_ERROR_MSG)).getMessage(),
                 vscCreationInfos.getErrorType().name(), reportService);
     }
 }

--- a/src/test/java/org/gridsuite/modification/server/modifications/VscCreationTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/VscCreationTest.java
@@ -319,6 +319,22 @@ public class VscCreationTest extends AbstractNetworkModificationTest {
     }
 
     @Test
+    public void testNotCreateAngleDroopPowerControlWithoutEnabling() throws Exception {
+        VscCreationInfos vscCreationInfos = (VscCreationInfos) buildModification();
+        vscCreationInfos.setAngleDroopActivePowerControl(false);
+        vscCreationInfos.setDroop(null);
+        vscCreationInfos.setP0(null);
+        String vscCreationInfosJson = mapper.writeValueAsString(vscCreationInfos);
+        mockMvc.perform(post(getNetworkModificationUri()).content(vscCreationInfosJson).contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+        assertThat(getNetwork().getHvdcLine("vsc1")).isNotNull();
+        HvdcLine hvdcLine = getNetwork().getHvdcLine("vsc1");
+        assertThat(hvdcLine).isNotNull();
+        HvdcAngleDroopActivePowerControl activePowerControlExt = hvdcLine.getExtension(HvdcAngleDroopActivePowerControl.class);
+        assertThat(activePowerControlExt).isNull();
+    }
+
+    @Test
     public void testAngleDroopPowerControlWithAbsentInfos() throws Exception {
         boolean[][] droopInfosIsPresentData = {
             {true, false, false},

--- a/src/test/java/org/gridsuite/modification/server/modifications/VscCreationTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/VscCreationTest.java
@@ -26,7 +26,7 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.gridsuite.modification.server.NetworkModificationException.Type.*;
-import static org.gridsuite.modification.server.modifications.ModificationUtils.ACTIVE_POWER_CONTROL_DROOP_P0_REQUIRED_ERROR_MSG;
+import static org.gridsuite.modification.server.modifications.VscModification.ACTIVE_POWER_CONTROL_DROOP_P0_REQUIRED_ERROR_MSG;
 import static org.gridsuite.modification.server.utils.TestUtils.assertLogMessage;
 import static org.junit.Assert.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;

--- a/src/test/java/org/gridsuite/modification/server/modifications/VscModificationTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/VscModificationTest.java
@@ -30,7 +30,7 @@ import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.gridsuite.modification.server.NetworkModificationException.Type.WRONG_HVDC_ANGLE_DROOP_ACTIVE_POWER_CONTROL;
-import static org.gridsuite.modification.server.modifications.VscModification.DROOP_ACTIVE_POWER_CONTROL_P0_DROOP_REQUIRED_ERROR_MSG;
+import static org.gridsuite.modification.server.modifications.VscModification.ACTIVE_POWER_CONTROL_DROOP_P0_REQUIRED_ERROR_MSG;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -256,8 +256,8 @@ public class VscModificationTest extends AbstractNetworkModificationTest {
         String message = Assert.assertThrows(NetworkModificationException.class,
                 () -> wrongVscModification.check(networkWithoutExt))
             .getMessage();
-        assertThat(message).isEqualTo(WRONG_HVDC_ANGLE_DROOP_ACTIVE_POWER_CONTROL.name() + " : " +
-            String.format(DROOP_ACTIVE_POWER_CONTROL_P0_DROOP_REQUIRED_ERROR_MSG));
+        assertThat(message).isEqualTo(WRONG_HVDC_ANGLE_DROOP_ACTIVE_POWER_CONTROL.name() + " : "
+              + ACTIVE_POWER_CONTROL_DROOP_P0_REQUIRED_ERROR_MSG);
     }
 
     @Test
@@ -272,8 +272,8 @@ public class VscModificationTest extends AbstractNetworkModificationTest {
         String message = Assert.assertThrows(NetworkModificationException.class,
                 () -> wrongVscModification.check(networkWithoutExt))
             .getMessage();
-        assertThat(message).isEqualTo(WRONG_HVDC_ANGLE_DROOP_ACTIVE_POWER_CONTROL.name() + " : " +
-              String.format(DROOP_ACTIVE_POWER_CONTROL_P0_DROOP_REQUIRED_ERROR_MSG));
+        assertThat(message).isEqualTo(WRONG_HVDC_ANGLE_DROOP_ACTIVE_POWER_CONTROL.name() + " : "
+              + ACTIVE_POWER_CONTROL_DROOP_P0_REQUIRED_ERROR_MSG);
     }
 
     @Test
@@ -289,7 +289,7 @@ public class VscModificationTest extends AbstractNetworkModificationTest {
                 () -> wrongVscModification.check(networkWithoutExt))
             .getMessage();
         assertThat(message).isEqualTo(WRONG_HVDC_ANGLE_DROOP_ACTIVE_POWER_CONTROL.name() + " : "
-              + String.format(DROOP_ACTIVE_POWER_CONTROL_P0_DROOP_REQUIRED_ERROR_MSG));
+              + ACTIVE_POWER_CONTROL_DROOP_P0_REQUIRED_ERROR_MSG);
     }
 
     @Test
@@ -311,27 +311,6 @@ public class VscModificationTest extends AbstractNetworkModificationTest {
         Assert.assertEquals(0, activePowerControl.getP0(), 0);
         Assert.assertEquals(10, activePowerControl.getDroop(), 0);
         Assert.assertTrue(activePowerControl.isEnabled());
-    }
-
-    @Test
-    public void testHvdcAngleDroopActivePowerControlWithoutP0() {
-        var networkuuid = UUID.randomUUID();
-        Network networkWithExt = NetworkCreation.createWithVSC(networkuuid, true);
-        VscModificationInfos modificationInfos = (VscModificationInfos) buildModification();
-        modificationInfos.setAngleDroopActivePowerControl(new AttributeModification<>(true, OperationType.SET));
-        { //Test : p0 should be required if drop is changed
-            modificationInfos.setDroop(new AttributeModification<>(10F, OperationType.SET));
-            modificationInfos.setP0(null);
-            VscModification vscModification = new VscModification(modificationInfos);
-            Assert.assertThrows(NetworkModificationException.class, () -> vscModification.check(networkWithExt));
-        }
-        { //Test : p0 should not be required if drop unchanged
-            modificationInfos.setDroop(null);
-            modificationInfos.setP0(null);
-            VscModification vscModification = new VscModification(modificationInfos);
-            assertDoesNotThrow(() -> vscModification.check(networkWithExt));
-
-        }
     }
 
     @Override

--- a/src/test/java/org/gridsuite/modification/server/modifications/VscModificationTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/VscModificationTest.java
@@ -30,7 +30,7 @@ import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.gridsuite.modification.server.NetworkModificationException.Type.WRONG_HVDC_ANGLE_DROOP_ACTIVE_POWER_CONTROL;
-import static org.gridsuite.modification.server.modifications.ModificationUtils.ACTIVE_POWER_CONTROL_DROOP_P0_REQUIRED_ERROR_MSG;
+import static org.gridsuite.modification.server.modifications.VscModification.ACTIVE_POWER_CONTROL_DROOP_P0_REQUIRED_ERROR_MSG;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -243,39 +243,6 @@ public class VscModificationTest extends AbstractNetworkModificationTest {
         Assert.assertEquals(1, activePowerControl.getDroop(), 0);
         Assert.assertTrue(activePowerControl.isEnabled());
     }
-
-//    @ParameterizedTest(name = "Test modification with absent droop infos when extension does not yet exist [{index}] {0}, {1}, {2}")
-//    @CsvSource({
-//        "true,false,false",
-//        "true,true,false",
-//        "true,false,true",
-//        "false,true,false",
-//        "false,true,true",
-//        "false,false,true",
-//    })
-//    void testHvdcAngleDroopActivePowerControlWithAbsentInfos(boolean isPresentAngleDroopActivePowerControl, boolean isPresentDroop, boolean isPresentP0) {
-//        var networkuuid = UUID.randomUUID();
-//        Network networkWithoutExt = NetworkCreation.createWithVSC(networkuuid, false);
-//        VscModificationInfos modificationInfos = (VscModificationInfos) buildModification();
-//
-//        // reset null depending to test arguments
-//        if (!isPresentAngleDroopActivePowerControl) {
-//            modificationInfos.setAngleDroopActivePowerControl(null);
-//        }
-//        if (!isPresentDroop) {
-//            modificationInfos.setDroop(null);
-//        }
-//        if (!isPresentP0) {
-//            modificationInfos.setP0(null);
-//        }
-//
-//        VscModification wrongVscModification = new VscModification(modificationInfos);
-//        String message = Assert.assertThrows(NetworkModificationException.class,
-//                () -> wrongVscModification.check(networkWithoutExt))
-//            .getMessage();
-//        assertThat(message).isEqualTo(WRONG_HVDC_ANGLE_DROOP_ACTIVE_POWER_CONTROL.name() + " : "
-//              + ACTIVE_POWER_CONTROL_DROOP_P0_REQUIRED_ERROR_MSG);
-//    }
 
     @Test
     public void testAngleDroopActivePowerControlWithAbsentInfos() {

--- a/src/test/java/org/gridsuite/modification/server/modifications/VscModificationTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/VscModificationTest.java
@@ -303,6 +303,7 @@ public class VscModificationTest extends AbstractNetworkModificationTest {
         assertDoesNotThrow(() -> vscModification.check(networkWithExt));
         vscModification.apply(networkWithExt, true, computationManager, subReporter);
         HvdcLine hvdcLine = networkWithExt.getHvdcLine("hvdcLine");
+        assertThat(hvdcLine).isNotNull();
         HvdcAngleDroopActivePowerControl activePowerControlExt = hvdcLine.getExtension(HvdcAngleDroopActivePowerControl.class);
         assertThat(activePowerControlExt).isNull();
     }
@@ -321,6 +322,7 @@ public class VscModificationTest extends AbstractNetworkModificationTest {
         assertDoesNotThrow(() -> vscModification.check(networkWithExt));
         vscModification.apply(networkWithExt, true, computationManager, subReporter);
         HvdcLine hvdcLine = networkWithExt.getHvdcLine("hvdcLine");
+        assertThat(hvdcLine).isNotNull();
         HvdcAngleDroopActivePowerControl activePowerControlExt = hvdcLine.getExtension(HvdcAngleDroopActivePowerControl.class);
         Assert.assertEquals(10, activePowerControlExt.getDroop(), 0);
         Assert.assertEquals(0, activePowerControlExt.getP0(), 0);
@@ -341,6 +343,7 @@ public class VscModificationTest extends AbstractNetworkModificationTest {
         assertDoesNotThrow(() -> vscModification.check(networkWithExt));
         vscModification.apply(networkWithExt, true, computationManager, subReporter);
         HvdcLine hvdcLine = networkWithExt.getHvdcLine("hvdcLine");
+        assertThat(hvdcLine).isNotNull();
         HvdcAngleDroopActivePowerControl activePowerControlExt = hvdcLine.getExtension(HvdcAngleDroopActivePowerControl.class);
         Assert.assertEquals(2, activePowerControlExt.getDroop(), 0);
         Assert.assertEquals(6, activePowerControlExt.getP0(), 0);

--- a/src/test/java/org/gridsuite/modification/server/modifications/VscModificationTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/VscModificationTest.java
@@ -32,7 +32,7 @@ import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.gridsuite.modification.server.NetworkModificationException.Type.WRONG_HVDC_ANGLE_DROOP_ACTIVE_POWER_CONTROL;
-import static org.gridsuite.modification.server.modifications.VscModification.ACTIVE_POWER_CONTROL_DROOP_P0_REQUIRED_ERROR_MSG;
+import static org.gridsuite.modification.server.modifications.ModificationUtils.ACTIVE_POWER_CONTROL_DROOP_P0_REQUIRED_ERROR_MSG;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -246,7 +246,7 @@ class VscModificationTest extends AbstractNetworkModificationTest {
         Assert.assertTrue(activePowerControl.isEnabled());
     }
 
-    @ParameterizedTest(name = "Test lack of provided values")
+    @ParameterizedTest(name = "Test modification with absent droop infos when extension does not yet exist [{index}] {0}, {1}, {2}")
     @CsvSource({
         "true,false,false",
         "true,true,false",
@@ -254,24 +254,24 @@ class VscModificationTest extends AbstractNetworkModificationTest {
         "false,true,false",
         "false,true,true",
         "false,false,true",
-        })
-    void testHvdcAngleDroopActivePowerControlWithNullValues(boolean isNullAngleDroopActivePowerControl, boolean isNullDroop, boolean isNullP0) {
+    })
+    void testHvdcAngleDroopActivePowerControlWithAbsentInfos(boolean isPresentAngleDroopActivePowerControl, boolean isPresentDroop, boolean isPresentP0) {
         var networkuuid = UUID.randomUUID();
         Network networkWithoutExt = NetworkCreation.createWithVSC(networkuuid, false);
-        VscModificationInfos wrongModificationInfos = (VscModificationInfos) buildModification();
+        VscModificationInfos modificationInfos = (VscModificationInfos) buildModification();
 
         // reset null depending to test arguments
-        if (isNullAngleDroopActivePowerControl) {
-            wrongModificationInfos.setAngleDroopActivePowerControl(null);
+        if (!isPresentAngleDroopActivePowerControl) {
+            modificationInfos.setAngleDroopActivePowerControl(null);
         }
-        if (isNullDroop) {
-            wrongModificationInfos.setDroop(null);
+        if (!isPresentDroop) {
+            modificationInfos.setDroop(null);
         }
-        if (isNullP0) {
-            wrongModificationInfos.setP0(null);
+        if (!isPresentP0) {
+            modificationInfos.setP0(null);
         }
 
-        VscModification wrongVscModification = new VscModification(wrongModificationInfos);
+        VscModification wrongVscModification = new VscModification(modificationInfos);
         String message = Assert.assertThrows(NetworkModificationException.class,
                 () -> wrongVscModification.check(networkWithoutExt))
             .getMessage();

--- a/src/test/java/org/gridsuite/modification/server/modifications/VscModificationTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/VscModificationTest.java
@@ -22,8 +22,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.util.CollectionUtils;
 
 import java.io.IOException;
@@ -41,7 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * @author jamal kheyyad <jamal.kheyyad at rte-france.com>
  */
 @Tag("IntegrationTest")
-class VscModificationTest extends AbstractNetworkModificationTest {
+public class VscModificationTest extends AbstractNetworkModificationTest {
 
     private static final String PROPERTY_NAME = "property-name";
     private static final String PROPERTY_VALUE = "property-value";
@@ -246,30 +244,47 @@ class VscModificationTest extends AbstractNetworkModificationTest {
         Assert.assertTrue(activePowerControl.isEnabled());
     }
 
-    @ParameterizedTest(name = "Test modification with absent droop infos when extension does not yet exist [{index}] {0}, {1}, {2}")
-    @CsvSource({
-        "true,false,false",
-        "true,true,false",
-        "true,false,true",
-        "false,true,false",
-        "false,true,true",
-        "false,false,true",
-    })
-    void testHvdcAngleDroopActivePowerControlWithAbsentInfos(boolean isPresentAngleDroopActivePowerControl, boolean isPresentDroop, boolean isPresentP0) {
+//    @ParameterizedTest(name = "Test modification with absent droop infos when extension does not yet exist [{index}] {0}, {1}, {2}")
+//    @CsvSource({
+//        "true,false,false",
+//        "true,true,false",
+//        "true,false,true",
+//        "false,true,false",
+//        "false,true,true",
+//        "false,false,true",
+//    })
+//    void testHvdcAngleDroopActivePowerControlWithAbsentInfos(boolean isPresentAngleDroopActivePowerControl, boolean isPresentDroop, boolean isPresentP0) {
+//        var networkuuid = UUID.randomUUID();
+//        Network networkWithoutExt = NetworkCreation.createWithVSC(networkuuid, false);
+//        VscModificationInfos modificationInfos = (VscModificationInfos) buildModification();
+//
+//        // reset null depending to test arguments
+//        if (!isPresentAngleDroopActivePowerControl) {
+//            modificationInfos.setAngleDroopActivePowerControl(null);
+//        }
+//        if (!isPresentDroop) {
+//            modificationInfos.setDroop(null);
+//        }
+//        if (!isPresentP0) {
+//            modificationInfos.setP0(null);
+//        }
+//
+//        VscModification wrongVscModification = new VscModification(modificationInfos);
+//        String message = Assert.assertThrows(NetworkModificationException.class,
+//                () -> wrongVscModification.check(networkWithoutExt))
+//            .getMessage();
+//        assertThat(message).isEqualTo(WRONG_HVDC_ANGLE_DROOP_ACTIVE_POWER_CONTROL.name() + " : "
+//              + ACTIVE_POWER_CONTROL_DROOP_P0_REQUIRED_ERROR_MSG);
+//    }
+
+    @Test
+    public void testAngleDroopActivePowerControlWithAbsentInfos() {
         var networkuuid = UUID.randomUUID();
         Network networkWithoutExt = NetworkCreation.createWithVSC(networkuuid, false);
         VscModificationInfos modificationInfos = (VscModificationInfos) buildModification();
 
-        // reset null depending to test arguments
-        if (!isPresentAngleDroopActivePowerControl) {
-            modificationInfos.setAngleDroopActivePowerControl(null);
-        }
-        if (!isPresentDroop) {
-            modificationInfos.setDroop(null);
-        }
-        if (!isPresentP0) {
-            modificationInfos.setP0(null);
-        }
+        modificationInfos.setDroop(null);
+        modificationInfos.setP0(null);
 
         VscModification wrongVscModification = new VscModification(modificationInfos);
         String message = Assert.assertThrows(NetworkModificationException.class,

--- a/src/test/java/org/gridsuite/modification/server/modifications/VscModificationTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/VscModificationTest.java
@@ -22,6 +22,8 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.util.CollectionUtils;
 
 import java.io.IOException;
@@ -244,46 +246,31 @@ public class VscModificationTest extends AbstractNetworkModificationTest {
         Assert.assertTrue(activePowerControl.isEnabled());
     }
 
-    @Test
-    public void testActivateHvdcAngleDroopActivePowerControlWithNullValues() {
+    @ParameterizedTest(name = "Test lack of provided values")
+    @CsvSource({
+        "true,false,false",
+        "true,true,false",
+        "true,false,true",
+        "false,true,false",
+        "false,true,true",
+        "false,false,true",
+        })
+    public void testHvdcAngleDroopActivePowerControlWithNullValues(boolean isNullAngleDroopActivePowerControl, boolean isNullDroop, boolean isNullP0) {
         var networkuuid = UUID.randomUUID();
         Network networkWithoutExt = NetworkCreation.createWithVSC(networkuuid, false);
         VscModificationInfos wrongModificationInfos = (VscModificationInfos) buildModification();
-        wrongModificationInfos.setDroop(null);
-        wrongModificationInfos.setP0(null);
-        wrongModificationInfos.setAngleDroopActivePowerControl(new AttributeModification<>(true, OperationType.SET));
-        VscModification wrongVscModification = new VscModification(wrongModificationInfos);
-        String message = Assert.assertThrows(NetworkModificationException.class,
-                () -> wrongVscModification.check(networkWithoutExt))
-            .getMessage();
-        assertThat(message).isEqualTo(WRONG_HVDC_ANGLE_DROOP_ACTIVE_POWER_CONTROL.name() + " : "
-              + ACTIVE_POWER_CONTROL_DROOP_P0_REQUIRED_ERROR_MSG);
-    }
 
-    @Test
-    public void testActivateHvdcAngleDroopActivePowerControlWithDroopNull() {
-        var networkuuid = UUID.randomUUID();
-        Network networkWithoutExt = NetworkCreation.createWithVSC(networkuuid, false);
-        VscModificationInfos wrongModificationInfos = (VscModificationInfos) buildModification();
-        wrongModificationInfos.setDroop(null);
-        wrongModificationInfos.setP0(new AttributeModification<>(100f, OperationType.SET));
-        wrongModificationInfos.setAngleDroopActivePowerControl(new AttributeModification<>(true, OperationType.SET));
-        VscModification wrongVscModification = new VscModification(wrongModificationInfos);
-        String message = Assert.assertThrows(NetworkModificationException.class,
-                () -> wrongVscModification.check(networkWithoutExt))
-            .getMessage();
-        assertThat(message).isEqualTo(WRONG_HVDC_ANGLE_DROOP_ACTIVE_POWER_CONTROL.name() + " : "
-              + ACTIVE_POWER_CONTROL_DROOP_P0_REQUIRED_ERROR_MSG);
-    }
+        // reset null depending to test arguments
+        if (isNullAngleDroopActivePowerControl) {
+            wrongModificationInfos.setAngleDroopActivePowerControl(null);
+        }
+        if (isNullDroop) {
+            wrongModificationInfos.setDroop(null);
+        }
+        if (isNullP0) {
+            wrongModificationInfos.setP0(null);
+        }
 
-    @Test
-    public void testActivateHvdcAngleDroopActivePowerControlWithP0Null() {
-        var networkuuid = UUID.randomUUID();
-        Network networkWithoutExt = NetworkCreation.createWithVSC(networkuuid, false);
-        VscModificationInfos wrongModificationInfos = (VscModificationInfos) buildModification();
-        wrongModificationInfos.setDroop(new AttributeModification<>(20f, OperationType.SET));
-        wrongModificationInfos.setP0(null);
-        wrongModificationInfos.setAngleDroopActivePowerControl(new AttributeModification<>(true, OperationType.SET));
         VscModification wrongVscModification = new VscModification(wrongModificationInfos);
         String message = Assert.assertThrows(NetworkModificationException.class,
                 () -> wrongVscModification.check(networkWithoutExt))

--- a/src/test/java/org/gridsuite/modification/server/modifications/VscModificationTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/VscModificationTest.java
@@ -224,7 +224,7 @@ public class VscModificationTest extends AbstractNetworkModificationTest {
     }
 
     @Test
-    public void testActivateHvdcAngleDroopActivePowerControl() throws Exception {
+    public void testActivateAngleDroopActivePowerControl() throws Exception {
         var networkuuid = UUID.randomUUID();
         Network networkWithoutExt = NetworkCreation.createWithVSC(networkuuid, false);
         VscModificationInfos modificationInfos = (VscModificationInfos) buildModification();
@@ -238,11 +238,11 @@ public class VscModificationTest extends AbstractNetworkModificationTest {
         HvdcLine hvdcLine = networkWithoutExt.getHvdcLine("hvdcLine");
         assertNotNull(hvdcLine);
 
-        HvdcAngleDroopActivePowerControl activePowerControl = hvdcLine.getExtension(HvdcAngleDroopActivePowerControl.class);
-        assertNotNull(activePowerControl);
-        Assert.assertEquals(5, activePowerControl.getP0(), 0);
-        Assert.assertEquals(1, activePowerControl.getDroop(), 0);
-        Assert.assertTrue(activePowerControl.isEnabled());
+        HvdcAngleDroopActivePowerControl activePowerControlExt = hvdcLine.getExtension(HvdcAngleDroopActivePowerControl.class);
+        assertNotNull(activePowerControlExt);
+        Assert.assertEquals(5, activePowerControlExt.getP0(), 0);
+        Assert.assertEquals(1, activePowerControlExt.getDroop(), 0);
+        Assert.assertTrue(activePowerControlExt.isEnabled());
     }
 
     @Test
@@ -294,7 +294,25 @@ public class VscModificationTest extends AbstractNetworkModificationTest {
     }
 
     @Test
-    public void testUnchangedHvdcAngleDroopActivePowerControl() throws Exception {
+    public void testNotCreateAngleDroopActivePowerControlExtension() throws Exception {
+        var networkuuid = UUID.randomUUID();
+        Network networkWithExt = NetworkCreation.createWithVSC(networkuuid, false);
+        VscModificationInfos modificationInfos = (VscModificationInfos) buildModification();
+        modificationInfos.setAngleDroopActivePowerControl(null);
+        modificationInfos.setDroop(null);
+        modificationInfos.setP0(null);
+        VscModification vscModification = new VscModification(modificationInfos);
+        ReportNode subReporter = ReportNode.NO_OP;
+        ComputationManager computationManager = new LocalComputationManager();
+        assertDoesNotThrow(() -> vscModification.check(networkWithExt));
+        vscModification.apply(networkWithExt, true, computationManager, subReporter);
+        HvdcLine hvdcLine = networkWithExt.getHvdcLine("hvdcLine");
+        HvdcAngleDroopActivePowerControl activePowerControlExt = hvdcLine.getExtension(HvdcAngleDroopActivePowerControl.class);
+        assertThat(activePowerControlExt).isNull();
+    }
+
+    @Test
+    public void testNotChangeAngleDroopActivePowerControlExtension() throws Exception {
         var networkuuid = UUID.randomUUID();
         Network networkWithExt = NetworkCreation.createWithVSC(networkuuid, true);
         VscModificationInfos modificationInfos = (VscModificationInfos) buildModification();
@@ -307,10 +325,30 @@ public class VscModificationTest extends AbstractNetworkModificationTest {
         assertDoesNotThrow(() -> vscModification.check(networkWithExt));
         vscModification.apply(networkWithExt, true, computationManager, subReporter);
         HvdcLine hvdcLine = networkWithExt.getHvdcLine("hvdcLine");
-        HvdcAngleDroopActivePowerControl activePowerControl = hvdcLine.getExtension(HvdcAngleDroopActivePowerControl.class);
-        Assert.assertEquals(0, activePowerControl.getP0(), 0);
-        Assert.assertEquals(10, activePowerControl.getDroop(), 0);
-        Assert.assertTrue(activePowerControl.isEnabled());
+        HvdcAngleDroopActivePowerControl activePowerControlExt = hvdcLine.getExtension(HvdcAngleDroopActivePowerControl.class);
+        Assert.assertEquals(10, activePowerControlExt.getDroop(), 0);
+        Assert.assertEquals(0, activePowerControlExt.getP0(), 0);
+        assertThat(activePowerControlExt.isEnabled()).isTrue();
+    }
+
+    @Test
+    public void testChangeAngleDroopActivePowerControlExtension() throws Exception {
+        var networkuuid = UUID.randomUUID();
+        Network networkWithExt = NetworkCreation.createWithVSC(networkuuid, true);
+        VscModificationInfos modificationInfos = (VscModificationInfos) buildModification();
+        modificationInfos.setAngleDroopActivePowerControl(new AttributeModification<>(false, OperationType.SET));
+        modificationInfos.setDroop(new AttributeModification<>(2.F, OperationType.SET));
+        modificationInfos.setP0(new AttributeModification<>(6F, OperationType.SET));
+        VscModification vscModification = new VscModification(modificationInfos);
+        ReportNode subReporter = ReportNode.NO_OP;
+        ComputationManager computationManager = new LocalComputationManager();
+        assertDoesNotThrow(() -> vscModification.check(networkWithExt));
+        vscModification.apply(networkWithExt, true, computationManager, subReporter);
+        HvdcLine hvdcLine = networkWithExt.getHvdcLine("hvdcLine");
+        HvdcAngleDroopActivePowerControl activePowerControlExt = hvdcLine.getExtension(HvdcAngleDroopActivePowerControl.class);
+        Assert.assertEquals(2, activePowerControlExt.getDroop(), 0);
+        Assert.assertEquals(6, activePowerControlExt.getP0(), 0);
+        assertThat(activePowerControlExt.isEnabled()).isFalse();
     }
 
     @Override

--- a/src/test/java/org/gridsuite/modification/server/modifications/VscModificationTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/VscModificationTest.java
@@ -224,7 +224,7 @@ public class VscModificationTest extends AbstractNetworkModificationTest {
     }
 
     @Test
-    public void testActivateAngleDroopActivePowerControl() throws Exception {
+    public void testCreateAngleDroopActivePowerControlWithEnabling() throws Exception {
         var networkuuid = UUID.randomUUID();
         Network networkWithoutExt = NetworkCreation.createWithVSC(networkuuid, false);
         VscModificationInfos modificationInfos = (VscModificationInfos) buildModification();
@@ -236,13 +236,13 @@ public class VscModificationTest extends AbstractNetworkModificationTest {
         vscModification.apply(networkWithoutExt, true, computationManager, subReporter);
 
         HvdcLine hvdcLine = networkWithoutExt.getHvdcLine("hvdcLine");
-        assertNotNull(hvdcLine);
+        assertThat(hvdcLine).isNotNull();
 
         HvdcAngleDroopActivePowerControl activePowerControlExt = hvdcLine.getExtension(HvdcAngleDroopActivePowerControl.class);
-        assertNotNull(activePowerControlExt);
+        assertThat(activePowerControlExt).isNotNull();
         Assert.assertEquals(5, activePowerControlExt.getP0(), 0);
         Assert.assertEquals(1, activePowerControlExt.getDroop(), 0);
-        Assert.assertTrue(activePowerControlExt.isEnabled());
+        assertThat(activePowerControlExt.isEnabled()).isTrue();
     }
 
     @Test
@@ -250,23 +250,19 @@ public class VscModificationTest extends AbstractNetworkModificationTest {
         var networkuuid = UUID.randomUUID();
         Network networkWithoutExt = NetworkCreation.createWithVSC(networkuuid, false);
 
-        VscModificationInfos modificationInfos = buildModificationWithDroopAbsentInfos(true, false, false);
-        checkDroopWithAbsentInfos(modificationInfos, networkWithoutExt);
+        boolean[][] droopInfosIsPresentData = {
+                {true, false, false},
+                {true, true, false},
+                {true, false, true},
+                {false, true, false},
+                {false, true, true},
+                {false, false, true},
+        };
 
-        modificationInfos = buildModificationWithDroopAbsentInfos(true, true, false);
-        checkDroopWithAbsentInfos(modificationInfos, networkWithoutExt);
-
-        modificationInfos = buildModificationWithDroopAbsentInfos(true, false, true);
-        checkDroopWithAbsentInfos(modificationInfos, networkWithoutExt);
-
-        modificationInfos = buildModificationWithDroopAbsentInfos(false, true, false);
-        checkDroopWithAbsentInfos(modificationInfos, networkWithoutExt);
-
-        modificationInfos = buildModificationWithDroopAbsentInfos(false, true, true);
-        checkDroopWithAbsentInfos(modificationInfos, networkWithoutExt);
-
-        modificationInfos = buildModificationWithDroopAbsentInfos(false, false, true);
-        checkDroopWithAbsentInfos(modificationInfos, networkWithoutExt);
+        for (boolean[] droopInfoIsPresent : droopInfosIsPresentData) {
+            VscModificationInfos modificationInfos = buildModificationWithDroopAbsentInfos(droopInfoIsPresent[0], droopInfoIsPresent[1], droopInfoIsPresent[2]);
+            checkDroopWithAbsentInfos(modificationInfos, networkWithoutExt);
+        }
     }
 
     private VscModificationInfos buildModificationWithDroopAbsentInfos(boolean isPresentAngleDroopActivePowerControl, boolean isPresentDroop, boolean isPresentP0) {
@@ -294,7 +290,7 @@ public class VscModificationTest extends AbstractNetworkModificationTest {
     }
 
     @Test
-    public void testNotCreateAngleDroopActivePowerControlExtension() throws Exception {
+    public void testNotCreateAngleDroopActivePowerControl() throws Exception {
         var networkuuid = UUID.randomUUID();
         Network networkWithExt = NetworkCreation.createWithVSC(networkuuid, false);
         VscModificationInfos modificationInfos = (VscModificationInfos) buildModification();
@@ -312,7 +308,7 @@ public class VscModificationTest extends AbstractNetworkModificationTest {
     }
 
     @Test
-    public void testNotChangeAngleDroopActivePowerControlExtension() throws Exception {
+    public void testNotChangeAngleDroopActivePowerControl() throws Exception {
         var networkuuid = UUID.randomUUID();
         Network networkWithExt = NetworkCreation.createWithVSC(networkuuid, true);
         VscModificationInfos modificationInfos = (VscModificationInfos) buildModification();
@@ -332,7 +328,7 @@ public class VscModificationTest extends AbstractNetworkModificationTest {
     }
 
     @Test
-    public void testChangeAngleDroopActivePowerControlExtension() throws Exception {
+    public void testChangeAngleDroopActivePowerControl() throws Exception {
         var networkuuid = UUID.randomUUID();
         Network networkWithExt = NetworkCreation.createWithVSC(networkuuid, true);
         VscModificationInfos modificationInfos = (VscModificationInfos) buildModification();

--- a/src/test/java/org/gridsuite/modification/server/modifications/VscModificationTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/VscModificationTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * @author jamal kheyyad <jamal.kheyyad at rte-france.com>
  */
 @Tag("IntegrationTest")
-public class VscModificationTest extends AbstractNetworkModificationTest {
+class VscModificationTest extends AbstractNetworkModificationTest {
 
     private static final String PROPERTY_NAME = "property-name";
     private static final String PROPERTY_VALUE = "property-value";
@@ -255,7 +255,7 @@ public class VscModificationTest extends AbstractNetworkModificationTest {
         "false,true,true",
         "false,false,true",
         })
-    public void testHvdcAngleDroopActivePowerControlWithNullValues(boolean isNullAngleDroopActivePowerControl, boolean isNullDroop, boolean isNullP0) {
+    void testHvdcAngleDroopActivePowerControlWithNullValues(boolean isNullAngleDroopActivePowerControl, boolean isNullDroop, boolean isNullP0) {
         var networkuuid = UUID.randomUUID();
         Network networkWithoutExt = NetworkCreation.createWithVSC(networkuuid, false);
         VscModificationInfos wrongModificationInfos = (VscModificationInfos) buildModification();


### PR DESCRIPTION
A PR completed for the previous PR: https://github.com/gridsuite/network-modification-server/pull/512

When extension is not yet created:

- If all fields are provided => OK
- If one of fields is provided and one of others fields not provided => NOK
- If none of fields is provided => OK