### PR TITLE
Clean logs to avoid duplicates between containers and logs

### DIFF
--- a/src/main/java/org/gridsuite/modification/server/modifications/AbstractBranchModification.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/AbstractBranchModification.java
@@ -44,7 +44,7 @@ public abstract class AbstractBranchModification extends AbstractModification {
                 .withSeverity(TypedValue.INFO_SEVERITY)
                 .add();
         if (branchModificationInfos.getEquipmentName() != null) {
-            insertReportNode(subReportNode, ModificationUtils.getInstance().buildModificationReportWithIndentation(Optional.of(branch.getOptionalName()).orElse(null), branchModificationInfos.getEquipmentName().getValue(), "Name", 0));
+            insertReportNode(subReportNode, ModificationUtils.getInstance().buildModificationReport(Optional.of(branch.getOptionalName()).orElse(null), branchModificationInfos.getEquipmentName().getValue(), "Name", 0));
             branch.setName(branchModificationInfos.getEquipmentName().getValue());
         }
 
@@ -114,7 +114,7 @@ public abstract class AbstractBranchModification extends AbstractModification {
     protected void modifyCurrentLimits(CurrentLimitsModificationInfos currentLimitsInfos, CurrentLimitsAdder limitsAdder, CurrentLimits currentLimits, List<ReportNode> limitsReports) {
         boolean hasPermanent = currentLimitsInfos.getPermanentLimit() != null;
         if (hasPermanent) {
-            limitsReports.add(ModificationUtils.getInstance().buildModificationReportWithIndentation(currentLimits != null ? currentLimits.getPermanentLimit() : Double.NaN,
+            limitsReports.add(ModificationUtils.getInstance().buildModificationReport(currentLimits != null ? currentLimits.getPermanentLimit() : Double.NaN,
                     currentLimitsInfos.getPermanentLimit(), "IST", 2));
             limitsAdder.setPermanentLimit(currentLimitsInfos.getPermanentLimit());
         } else {

--- a/src/main/java/org/gridsuite/modification/server/modifications/AbstractBranchModification.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/AbstractBranchModification.java
@@ -18,7 +18,6 @@ import org.gridsuite.modification.server.dto.TemporaryLimitModificationType;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.gridsuite.modification.server.NetworkModificationException.Type.BRANCH_MODIFICATION_ERROR;
@@ -71,9 +70,9 @@ public abstract class AbstractBranchModification extends AbstractModification {
                     .withSeverity(TypedValue.INFO_SEVERITY)
                     .add();
             ModificationUtils.getInstance().reportModifications(limitsReportNode, side1LimitsReports, "side1LimitsModification",
-                    "    Side 1", Map.of());
+                    "    Side 1");
             ModificationUtils.getInstance().reportModifications(limitsReportNode, side2LimitsReports, "side2LimitsModification",
-                    "    Side 2", Map.of());
+                    "    Side 2");
         }
 
         updateConnections(branch, branchModificationInfos);

--- a/src/main/java/org/gridsuite/modification/server/modifications/AbstractBranchModification.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/AbstractBranchModification.java
@@ -18,6 +18,7 @@ import org.gridsuite.modification.server.dto.TemporaryLimitModificationType;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.gridsuite.modification.server.NetworkModificationException.Type.BRANCH_MODIFICATION_ERROR;
@@ -43,7 +44,7 @@ public abstract class AbstractBranchModification extends AbstractModification {
                 .withSeverity(TypedValue.INFO_SEVERITY)
                 .add();
         if (branchModificationInfos.getEquipmentName() != null) {
-            insertReportNode(subReportNode, ModificationUtils.getInstance().buildModificationReportWithIndentation(branch.getOptionalName().isEmpty() ? null : branch.getOptionalName().get(), branchModificationInfos.getEquipmentName().getValue(), "Name", 0));
+            insertReportNode(subReportNode, ModificationUtils.getInstance().buildModificationReportWithIndentation(Optional.of(branch.getOptionalName()).orElse(null), branchModificationInfos.getEquipmentName().getValue(), "Name", 0));
             branch.setName(branchModificationInfos.getEquipmentName().getValue());
         }
 
@@ -65,10 +66,6 @@ public abstract class AbstractBranchModification extends AbstractModification {
         }
         if (!side1LimitsReports.isEmpty() || !side2LimitsReports.isEmpty()) {
             ReportNode limitsReportNode = subReportNode.newReportNode().withMessageTemplate("limits", "Limits").add();
-            limitsReportNode.newReportNode()
-                    .withMessageTemplate("limitsModification", "Limits")
-                    .withSeverity(TypedValue.INFO_SEVERITY)
-                    .add();
             ModificationUtils.getInstance().reportModifications(limitsReportNode, side1LimitsReports, "side1LimitsModification",
                     "    Side 1");
             ModificationUtils.getInstance().reportModifications(limitsReportNode, side2LimitsReports, "side2LimitsModification",
@@ -205,7 +202,7 @@ public abstract class AbstractBranchModification extends AbstractModification {
             }
         }
         if (!temporaryLimitsReports.isEmpty()) {
-            temporaryLimitsReports.add(ReportNode.newRootReportNode()
+            temporaryLimitsReports.add(0, ReportNode.newRootReportNode()
                     .withMessageTemplate("temporaryLimitsModification", "            Temporary current limits :")
                     .withSeverity(TypedValue.INFO_SEVERITY)
                     .build());

--- a/src/main/java/org/gridsuite/modification/server/modifications/BatteryCreation.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/BatteryCreation.java
@@ -182,18 +182,12 @@ public class BatteryCreation extends AbstractModification {
     }
 
     private ReportNode reportBatteryActiveLimits(BatteryCreationInfos batteryCreationInfos, ReportNode subReportNode) {
-        List<ReportNode> limitsReports = new ArrayList<>();
         ReportNode subReportNodeLimits = subReportNode.newReportNode().withMessageTemplate(LIMITS, LIMITS).add();
-        subReportNodeLimits.newReportNode()
-            .withMessageTemplate(LIMITS, LIMITS)
-            .withSeverity(TypedValue.INFO_SEVERITY)
-            .add();
+        List<ReportNode> limitsReports = new ArrayList<>();
         limitsReports.add(ModificationUtils.getInstance().buildCreationReport(
             batteryCreationInfos.getMinP(), "Min active power"));
-
         limitsReports.add(ModificationUtils.getInstance().buildCreationReport(
             batteryCreationInfos.getMaxP(), "Max active power"));
-
         ModificationUtils.getInstance().reportModifications(subReportNodeLimits, limitsReports, "ActiveLimitsCreated", ACTIVE_LIMITS);
         return subReportNodeLimits;
     }

--- a/src/main/java/org/gridsuite/modification/server/modifications/BatteryCreation.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/BatteryCreation.java
@@ -18,7 +18,6 @@ import org.gridsuite.modification.server.dto.BatteryCreationInfos;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import static org.gridsuite.modification.server.NetworkModificationException.Type.BATTERY_ALREADY_EXISTS;
 import static org.gridsuite.modification.server.modifications.ModificationUtils.nanIfNull;
@@ -147,7 +146,7 @@ public class BatteryCreation extends AbstractModification {
             setPointReports.add(ModificationUtils.getInstance()
                 .buildCreationReport(batteryCreationInfos.getTargetQ(), "Reactive power"));
         }
-        return ModificationUtils.getInstance().reportModifications(subReportNode, setPointReports, "SetPointCreated", "Setpoints", Map.of());
+        return ModificationUtils.getInstance().reportModifications(subReportNode, setPointReports, "SetPointCreated", "Setpoints");
     }
 
     private void reportBatteryConnectivity(BatteryCreationInfos batteryCreationInfos, ReportNode subReportNode) {
@@ -178,7 +177,7 @@ public class BatteryCreation extends AbstractModification {
                         .withSeverity(TypedValue.INFO_SEVERITY)
                         .build());
             }
-            ModificationUtils.getInstance().reportModifications(subReportNode, connectivityReports, "ConnectivityCreated", CONNECTIVITY, Map.of());
+            ModificationUtils.getInstance().reportModifications(subReportNode, connectivityReports, "ConnectivityCreated", CONNECTIVITY);
         }
     }
 
@@ -195,7 +194,7 @@ public class BatteryCreation extends AbstractModification {
         limitsReports.add(ModificationUtils.getInstance().buildCreationReport(
             batteryCreationInfos.getMaxP(), "Max active power"));
 
-        ModificationUtils.getInstance().reportModifications(subReportNodeLimits, limitsReports, "ActiveLimitsCreated", ACTIVE_LIMITS, Map.of());
+        ModificationUtils.getInstance().reportModifications(subReportNodeLimits, limitsReports, "ActiveLimitsCreated", ACTIVE_LIMITS);
         return subReportNodeLimits;
     }
 
@@ -221,7 +220,7 @@ public class BatteryCreation extends AbstractModification {
                         .withSeverity(TypedValue.ERROR_SEVERITY)
                         .build());
             }
-            ModificationUtils.getInstance().reportModifications(subReporter, activePowerRegulationReports, "ActivePowerRegulationCreated", "Active power regulation", Map.of());
+            ModificationUtils.getInstance().reportModifications(subReporter, activePowerRegulationReports, "ActivePowerRegulationCreated", "Active power regulation");
         }
     }
 }

--- a/src/main/java/org/gridsuite/modification/server/modifications/BatteryModification.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/BatteryModification.java
@@ -98,10 +98,6 @@ public class BatteryModification extends AbstractModification {
         ReportNode subReporterSetpoints = null;
         if (reportActivePower != null || reportReactivePower != null) {
             subReporterSetpoints = subReportNode.newReportNode().withMessageTemplate(SETPOINTS, SETPOINTS).add();
-            subReporterSetpoints.newReportNode()
-                    .withMessageTemplate(SETPOINTS, SETPOINTS)
-                    .withSeverity(TypedValue.INFO_SEVERITY)
-                    .add();
             if (reportActivePower != null) {
                 insertReportNode(subReporterSetpoints, reportActivePower);
             }
@@ -134,16 +130,7 @@ public class BatteryModification extends AbstractModification {
         ReportNode reportMinActivePower = ModificationUtils.getInstance().applyElementaryModificationsAndReturnReport(battery::setMinP, battery::getMinP, modificationInfos.getMinP(), "Min active power");
         if (reportMaxActivePower != null || reportMinActivePower != null) {
             subReportNodeLimits = subReportNode.newReportNode().withMessageTemplate(LIMITS, LIMITS).add();
-            subReportNodeLimits.newReportNode()
-                    .withMessageTemplate(LIMITS, LIMITS)
-                    .withSeverity(TypedValue.INFO_SEVERITY)
-                    .add();
-
             ReportNode subReporterActiveLimits = subReportNodeLimits.newReportNode().withMessageTemplate(ACTIVE_LIMITS, ACTIVE_LIMITS).add();
-            subReporterActiveLimits.newReportNode()
-                    .withMessageTemplate(ACTIVE_LIMITS, ACTIVE_LIMITS)
-                    .withSeverity(TypedValue.INFO_SEVERITY)
-                    .add();
             if (reportMaxActivePower != null) {
                 insertReportNode(subReporterActiveLimits, reportMaxActivePower);
             }

--- a/src/main/java/org/gridsuite/modification/server/modifications/ByFormulaModification.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/ByFormulaModification.java
@@ -118,10 +118,6 @@ public class ByFormulaModification extends AbstractModification {
     }
 
     private void report(ReportNode formulaSubReportNode, List<ReportNode> formulaReports) {
-        formulaSubReportNode.newReportNode()
-                .withMessageTemplate("appliedFormulasModifications", "  Formulas")
-                .withSeverity(TypedValue.INFO_SEVERITY)
-                .add();
         formulaReports.forEach(report -> insertReportNode(formulaSubReportNode, report));
     }
 

--- a/src/main/java/org/gridsuite/modification/server/modifications/GeneratorCreation.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/GeneratorCreation.java
@@ -27,7 +27,6 @@ import org.gridsuite.modification.server.dto.GeneratorCreationInfos;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import static org.gridsuite.modification.server.NetworkModificationException.Type.GENERATOR_ALREADY_EXISTS;
 import static org.gridsuite.modification.server.modifications.ModificationUtils.nanIfNull;
@@ -190,7 +189,7 @@ public class GeneratorCreation extends AbstractModification {
             setPointReports.add(ModificationUtils.getInstance()
                 .buildCreationReport(generatorCreationInfos.getTargetQ(), "Reactive power"));
         }
-        return ModificationUtils.getInstance().reportModifications(subReportNode, setPointReports, "SetPointCreated", "Setpoints", Map.of());
+        return ModificationUtils.getInstance().reportModifications(subReportNode, setPointReports, "SetPointCreated", "Setpoints");
     }
 
     private void createGeneratorVoltageRegulation(GeneratorCreationInfos generatorCreationInfos, Generator generator, VoltageLevel voltageLevel, ReportNode subReportNode) {
@@ -222,7 +221,7 @@ public class GeneratorCreation extends AbstractModification {
                         .build());
             }
         }
-        ModificationUtils.getInstance().reportModifications(subReportNode, voltageReports, "VoltageRegulationCreated", "Voltage regulation", Map.of());
+        ModificationUtils.getInstance().reportModifications(subReportNode, voltageReports, "VoltageRegulationCreated", "Voltage regulation");
 
     }
 
@@ -270,7 +269,7 @@ public class GeneratorCreation extends AbstractModification {
                         .withSeverity(TypedValue.INFO_SEVERITY)
                         .build());
             }
-            ModificationUtils.getInstance().reportModifications(subReporter, connectivityReports, "ConnectivityCreated", CONNECTIVITY, Map.of());
+            ModificationUtils.getInstance().reportModifications(subReporter, connectivityReports, "ConnectivityCreated", CONNECTIVITY);
         }
     }
 
@@ -292,7 +291,7 @@ public class GeneratorCreation extends AbstractModification {
             limitsReports.add(ModificationUtils.getInstance().buildCreationReport(
                 generatorCreationInfos.getRatedS(), "Rated nominal power"));
         }
-        ModificationUtils.getInstance().reportModifications(subReportNodeLimits, limitsReports, "ActiveLimitsCreated", ACTIVE_LIMITS, Map.of());
+        ModificationUtils.getInstance().reportModifications(subReportNodeLimits, limitsReports, "ActiveLimitsCreated", ACTIVE_LIMITS);
         return subReportNodeLimits;
     }
 
@@ -319,7 +318,7 @@ public class GeneratorCreation extends AbstractModification {
                         .build());
 
             }
-            ModificationUtils.getInstance().reportModifications(subReportNode, activePowerRegulationReports, "ActivePowerRegulationCreated", "Active power regulation", Map.of());
+            ModificationUtils.getInstance().reportModifications(subReportNode, activePowerRegulationReports, "ActivePowerRegulationCreated", "Active power regulation");
         }
     }
 
@@ -345,7 +344,7 @@ public class GeneratorCreation extends AbstractModification {
                         .withSeverity(TypedValue.ERROR_SEVERITY)
                         .build());
             }
-            ModificationUtils.getInstance().reportModifications(subReportNode, shortCircuitReports, "shortCircuitCreated", "Short-circuit", Map.of());
+            ModificationUtils.getInstance().reportModifications(subReportNode, shortCircuitReports, "shortCircuitCreated", "Short-circuit");
         }
     }
 
@@ -386,7 +385,7 @@ public class GeneratorCreation extends AbstractModification {
                         .withSeverity(TypedValue.ERROR_SEVERITY)
                         .build());
             }
-            ModificationUtils.getInstance().reportModifications(subReportNode, startupReports, "startUpAttributesCreated", "Start up", Map.of());
+            ModificationUtils.getInstance().reportModifications(subReportNode, startupReports, "startUpAttributesCreated", "Start up");
         }
     }
 }

--- a/src/main/java/org/gridsuite/modification/server/modifications/GeneratorCreation.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/GeneratorCreation.java
@@ -274,19 +274,12 @@ public class GeneratorCreation extends AbstractModification {
     }
 
     private ReportNode reportGeneratorActiveLimits(GeneratorCreationInfos generatorCreationInfos, ReportNode subReportNode) {
-        List<ReportNode> limitsReports = new ArrayList<>();
         ReportNode subReportNodeLimits = subReportNode.newReportNode().withMessageTemplate(LIMITS, LIMITS).add();
-        subReportNodeLimits.newReportNode()
-                .withMessageTemplate(LIMITS, LIMITS)
-                .withSeverity(TypedValue.INFO_SEVERITY)
-                .add();
-
+        List<ReportNode> limitsReports = new ArrayList<>();
         limitsReports.add(ModificationUtils.getInstance().buildCreationReport(
             generatorCreationInfos.getMinP(), "Min active power"));
-
         limitsReports.add(ModificationUtils.getInstance().buildCreationReport(
             generatorCreationInfos.getMaxP(), "Max active power"));
-
         if (generatorCreationInfos.getRatedS() != null) {
             limitsReports.add(ModificationUtils.getInstance().buildCreationReport(
                 generatorCreationInfos.getRatedS(), "Rated nominal power"));

--- a/src/main/java/org/gridsuite/modification/server/modifications/GeneratorModification.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/GeneratorModification.java
@@ -166,16 +166,7 @@ public class GeneratorModification extends AbstractModification {
         ReportNode reportRatedNominalPower = ModificationUtils.getInstance().applyElementaryModificationsAndReturnReport(generator::setRatedS, generator::getRatedS, modificationInfos.getRatedS(), "Rated nominal power");
         if (reportMaxActivePower != null || reportMinActivePower != null || reportRatedNominalPower != null) {
             subReporterLimits = subReportNode.newReportNode().withMessageTemplate(LIMITS, LIMITS).add();
-            subReporterLimits.newReportNode()
-                    .withMessageTemplate(LIMITS, LIMITS)
-                    .withSeverity(TypedValue.INFO_SEVERITY)
-                    .add();
-
             ReportNode subReporterActiveLimits = subReporterLimits.newReportNode().withMessageTemplate(ACTIVE_LIMITS, ACTIVE_LIMITS).add();
-            subReporterActiveLimits.newReportNode()
-                    .withMessageTemplate(ACTIVE_LIMITS, ACTIVE_LIMITS)
-                    .withSeverity(TypedValue.INFO_SEVERITY)
-                    .add();
             if (reportMaxActivePower != null) {
                 insertReportNode(subReporterActiveLimits, reportMaxActivePower);
             }
@@ -394,10 +385,6 @@ public class GeneratorModification extends AbstractModification {
             subReportNodeSetpoints2 = subReportNode.newReportNode()
                             .withMessageTemplate(SETPOINTS, SETPOINTS)
                             .add();
-            subReportNodeSetpoints2.newReportNode()
-                    .withMessageTemplate(SETPOINTS, SETPOINTS)
-                    .withSeverity(TypedValue.INFO_SEVERITY)
-                    .add();
         }
         ModificationUtils.getInstance().reportModifications(subReportNodeSetpoints2, voltageRegulationReports, "voltageRegulationModified", "Voltage regulation");
         return subReportNodeSetpoints2;
@@ -418,10 +405,6 @@ public class GeneratorModification extends AbstractModification {
         ReportNode subReporterSetpoints = null;
         if (reportActivePower != null || reportReactivePower != null) {
             subReporterSetpoints = subReportNode.newReportNode().withMessageTemplate(SETPOINTS, SETPOINTS).add();
-            subReporterSetpoints.newReportNode()
-                    .withMessageTemplate(SETPOINTS, SETPOINTS)
-                    .withSeverity(TypedValue.INFO_SEVERITY)
-                    .add();
             if (reportActivePower != null) {
                 insertReportNode(subReporterSetpoints, reportActivePower);
             }

--- a/src/main/java/org/gridsuite/modification/server/modifications/GeneratorModification.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/GeneratorModification.java
@@ -17,7 +17,6 @@ import org.gridsuite.modification.server.dto.*;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 
 import static org.gridsuite.modification.server.NetworkModificationException.Type.MODIFY_GENERATOR_ERROR;
 import static org.gridsuite.modification.server.modifications.ModificationUtils.insertReportNode;
@@ -139,7 +138,7 @@ public class GeneratorModification extends AbstractModification {
                     modificationInfos.getStepUpTransformerX().getValue(),
                     "Transformer reactance"));
         }
-        ModificationUtils.getInstance().reportModifications(subReportNode, reports, "shortCircuitAttributesModified", "Short-circuit", Map.of());
+        ModificationUtils.getInstance().reportModifications(subReportNode, reports, "shortCircuitAttributesModified", "Short-circuit");
     }
 
     private void modifyGeneratorReactiveCapabilityCurvePoints(GeneratorModificationInfos modificationInfos,
@@ -230,7 +229,7 @@ public class GeneratorModification extends AbstractModification {
                 plannedOutageRateUpdated ||
                 forcedOutageRateUpdated) {
             generatorStartupAdder.add();
-            ModificationUtils.getInstance().reportModifications(subReportNode, reports, "startUpAttributesModified", "Start up", Map.of());
+            ModificationUtils.getInstance().reportModifications(subReportNode, reports, "startUpAttributesModified", "Start up");
         }
     }
 
@@ -400,7 +399,7 @@ public class GeneratorModification extends AbstractModification {
                     .withSeverity(TypedValue.INFO_SEVERITY)
                     .add();
         }
-        ModificationUtils.getInstance().reportModifications(subReportNodeSetpoints2, voltageRegulationReports, "voltageRegulationModified", "Voltage regulation", Map.of());
+        ModificationUtils.getInstance().reportModifications(subReportNodeSetpoints2, voltageRegulationReports, "voltageRegulationModified", "Voltage regulation");
         return subReportNodeSetpoints2;
     }
 

--- a/src/main/java/org/gridsuite/modification/server/modifications/GeneratorModification.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/GeneratorModification.java
@@ -348,9 +348,11 @@ public class GeneratorModification extends AbstractModification {
                 reportVoltageSetpoint = ModificationUtils.getInstance().buildModificationReport(generator.getTargetV(), Double.NaN, "Voltage");
             }
         }
-
-        voltageRegulationReports.add(ModificationUtils.getInstance().applyElementaryModificationsAndReturnReport(generator::setVoltageRegulatorOn, generator::isVoltageRegulatorOn,
-                modificationInfos.getVoltageRegulationOn(), "VoltageRegulationOn"));
+        ReportNode voltageRegulationOn = ModificationUtils.getInstance().applyElementaryModificationsAndReturnReport(generator::setVoltageRegulatorOn, generator::isVoltageRegulatorOn,
+                modificationInfos.getVoltageRegulationOn(), "VoltageRegulationOn");
+        if (voltageRegulationOn != null) {
+            voltageRegulationReports.add(voltageRegulationOn);
+        }
         if (reportVoltageSetpoint != null) {
             voltageRegulationReports.add(reportVoltageSetpoint);
         }

--- a/src/main/java/org/gridsuite/modification/server/modifications/LineModification.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/LineModification.java
@@ -7,7 +7,6 @@
 package org.gridsuite.modification.server.modifications;
 
 import com.powsybl.commons.report.ReportNode;
-import com.powsybl.commons.report.TypedValue;
 import com.powsybl.iidm.network.Branch;
 import com.powsybl.iidm.network.Line;
 import com.powsybl.iidm.network.Network;
@@ -52,17 +51,13 @@ public class LineModification extends AbstractBranchModification {
     protected void modifyCharacteristics(Branch<?> branch, BranchModificationInfos branchModificationInfos, ReportNode subReportNode) {
         Line line = (Line) branch;
         ReportNode characteristicsReporter = subReportNode.newReportNode().withMessageTemplate("characteristics", "Characteristics").add();
-        characteristicsReporter.newReportNode()
-            .withMessageTemplate("characteristicsModification", "Characteristics")
-            .withSeverity(TypedValue.INFO_SEVERITY)
-            .add();
         if (branchModificationInfos.getR() != null && branchModificationInfos.getR().getValue() != null) {
-            insertReportNode(characteristicsReporter, ModificationUtils.getInstance().buildModificationReportWithIndentation(line.getR(),
+            insertReportNode(characteristicsReporter, ModificationUtils.getInstance().buildModificationReport(line.getR(),
                     branchModificationInfos.getR().getValue(), "Series resistance", 1));
             line.setR(branchModificationInfos.getR().getValue());
         }
         if (branchModificationInfos.getX() != null && branchModificationInfos.getX().getValue() != null) {
-            insertReportNode(characteristicsReporter, ModificationUtils.getInstance().buildModificationReportWithIndentation(line.getX(),
+            insertReportNode(characteristicsReporter, ModificationUtils.getInstance().buildModificationReport(line.getX(),
                     branchModificationInfos.getX().getValue(), "Series reactance", 1));
             line.setX(branchModificationInfos.getX().getValue());
         }
@@ -78,15 +73,11 @@ public class LineModification extends AbstractBranchModification {
         if (lineModificationInfos.getG1() != null && lineModificationInfos.getG1().getValue() != null
                 || lineModificationInfos.getB1() != null && lineModificationInfos.getB1().getValue() != null) {
             ReportNode side1ReportNode = characteristicsReportNode.newReportNode().withMessageTemplate("side1Characteristics", "Side 1").add();
-            side1ReportNode.newReportNode()
-                    .withMessageTemplate("side1CharacteristicsModification", "    Side 1")
-                    .withSeverity(TypedValue.INFO_SEVERITY)
-                    .add();
             if (lineModificationInfos.getG1() != null && lineModificationInfos.getG1().getValue() != null) {
                 //convert reported value from siemens to microsiemens
                 double shuntConductance1ToReport = lineModificationInfos.getG1().getValue() * Math.pow(10, 6);
                 double oldShuntConductance1ToReport = line.getG1() * Math.pow(10, 6);
-                insertReportNode(side1ReportNode, ModificationUtils.getInstance().buildModificationReportWithIndentation(oldShuntConductance1ToReport,
+                insertReportNode(side1ReportNode, ModificationUtils.getInstance().buildModificationReport(oldShuntConductance1ToReport,
                         shuntConductance1ToReport, "Shunt conductance", 2));
                 line.setG1(lineModificationInfos.getG1().getValue());
             }
@@ -94,7 +85,7 @@ public class LineModification extends AbstractBranchModification {
                 //convert reported value from siemens to microsiemens
                 double shuntSusceptance1ToReport = lineModificationInfos.getB1().getValue() * Math.pow(10, 6);
                 double oldShuntSusceptance1ToReport = line.getB1() * Math.pow(10, 6);
-                insertReportNode(side1ReportNode, ModificationUtils.getInstance().buildModificationReportWithIndentation(oldShuntSusceptance1ToReport,
+                insertReportNode(side1ReportNode, ModificationUtils.getInstance().buildModificationReport(oldShuntSusceptance1ToReport,
                         shuntSusceptance1ToReport, "Shunt susceptance", 2));
                 line.setB1(lineModificationInfos.getB1().getValue());
             }
@@ -106,15 +97,11 @@ public class LineModification extends AbstractBranchModification {
         if (lineModificationInfos.getG2() != null && lineModificationInfos.getG2().getValue() != null
                 || lineModificationInfos.getB2() != null && lineModificationInfos.getB2().getValue() != null) {
             ReportNode side2Reporter = characteristicsReportNode.newReportNode().withMessageTemplate("side2Characteristics", "Side 2").add();
-            side2Reporter.newReportNode()
-                    .withMessageTemplate("side2CharacteristicsModification", "    Side 2")
-                    .withSeverity(TypedValue.INFO_SEVERITY)
-                    .add();
             if (lineModificationInfos.getG2() != null && lineModificationInfos.getG2().getValue() != null) {
                 // convert reported value from siemens to microsiemens
                 double shuntConductance2ToReport = lineModificationInfos.getG2().getValue() * Math.pow(10, 6);
                 double oldShuntConductance2ToReport = line.getG2() * Math.pow(10, 6);
-                insertReportNode(side2Reporter, ModificationUtils.getInstance().buildModificationReportWithIndentation(oldShuntConductance2ToReport,
+                insertReportNode(side2Reporter, ModificationUtils.getInstance().buildModificationReport(oldShuntConductance2ToReport,
                         shuntConductance2ToReport, "Shunt conductance", 2));
                 line.setG2(lineModificationInfos.getG2().getValue());
             }
@@ -122,7 +109,7 @@ public class LineModification extends AbstractBranchModification {
                 // convert reported value from siemens to microsiemens
                 double shuntSusceptance2ToReport = lineModificationInfos.getB2().getValue() * Math.pow(10, 6);
                 double oldShuntSusceptance2ToReport = line.getB2() * Math.pow(10, 6);
-                insertReportNode(side2Reporter, ModificationUtils.getInstance().buildModificationReportWithIndentation(oldShuntSusceptance2ToReport,
+                insertReportNode(side2Reporter, ModificationUtils.getInstance().buildModificationReport(oldShuntSusceptance2ToReport,
                         shuntSusceptance2ToReport, "Shunt susceptance", 2));
                 line.setB2(lineModificationInfos.getB2().getValue());
             }

--- a/src/main/java/org/gridsuite/modification/server/modifications/ModificationUtils.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/ModificationUtils.java
@@ -853,20 +853,13 @@ public final class ModificationUtils {
         adder.add();
         ReportNode subReportNodeReactiveLimits = null;
         ReportNode subReporterLimits2 = subReportNodeLimits;
-        if (subReportNodeLimits == null && !reports.isEmpty()) {
-            subReporterLimits2 = subReportNode.newReportNode().withMessageTemplate(LIMITS, LIMITS).add();
-            subReporterLimits2.newReportNode().withMessageTemplate(LIMITS, LIMITS).add();
-            subReporterLimits2.newReportNode()
-                    .withMessageTemplate(LIMITS, LIMITS)
-                    .withSeverity(TypedValue.INFO_SEVERITY)
-                    .add();
-        }
-        if (subReporterLimits2 != null && !reports.isEmpty()) {
-            subReportNodeReactiveLimits = subReporterLimits2.newReportNode().withMessageTemplate(REACTIVE_LIMITS, REACTIVE_LIMITS).add();
-            subReportNodeReactiveLimits.newReportNode()
-                    .withMessageTemplate(REACTIVE_LIMITS, REACTIVE_LIMITS)
-                    .withSeverity(TypedValue.INFO_SEVERITY)
-                    .add();
+        if (!reports.isEmpty()) {
+            if (subReportNodeLimits == null) {
+                subReporterLimits2 = subReportNode.newReportNode().withMessageTemplate(LIMITS, LIMITS).add();
+            }
+            if (subReporterLimits2 != null) {
+                subReportNodeReactiveLimits = subReporterLimits2.newReportNode().withMessageTemplate(REACTIVE_LIMITS, REACTIVE_LIMITS).add();
+            }
         }
         reportModifications(subReportNodeReactiveLimits, reports, "curveReactiveLimitsModified", "By diagram");
     }
@@ -966,17 +959,9 @@ public final class ModificationUtils {
         ReportNode subReportNodeLimits2 = subReportNodeLimits;
         if (subReportNodeLimits == null && !reports.isEmpty()) {
             subReportNodeLimits2 = subReportNode.newReportNode().withMessageTemplate(LIMITS, LIMITS).add();
-            subReportNodeLimits2.newReportNode()
-                    .withMessageTemplate(LIMITS, LIMITS)
-                    .withSeverity(TypedValue.INFO_SEVERITY)
-                    .add();
         }
         if (subReportNodeLimits2 != null && !reports.isEmpty()) {
             subReportNodeReactiveLimits = subReportNodeLimits2.newReportNode().withMessageTemplate(REACTIVE_LIMITS, REACTIVE_LIMITS).add();
-            subReportNodeReactiveLimits.newReportNode()
-                    .withMessageTemplate(REACTIVE_LIMITS, REACTIVE_LIMITS)
-                    .withSeverity(TypedValue.INFO_SEVERITY)
-                    .add();
         }
         reportModifications(subReportNodeReactiveLimits, reports, "minMaxReactiveLimitsModified", "By range");
     }
@@ -1032,10 +1017,6 @@ public final class ModificationUtils {
         ReportNode subReportNodeSetpoints2 = subReporterSetpoints;
         if (subReporterSetpoints == null && !reports.isEmpty()) {
             subReportNodeSetpoints2 = subReportNode.newReportNode().withMessageTemplate(SETPOINTS, SETPOINTS).add();
-            subReportNodeSetpoints2.newReportNode()
-                    .withMessageTemplate(SETPOINTS, SETPOINTS)
-                    .withSeverity(TypedValue.INFO_SEVERITY)
-                    .add();
         }
         reportModifications(subReportNodeSetpoints2, reports, "activePowerRegulationModified", "Active power regulation");
         return subReportNodeSetpoints2;
@@ -1180,10 +1161,6 @@ public final class ModificationUtils {
                     MAX_REACTIVE_POWER_FIELDNAME));
 
             ReportNode subReporterReactiveLimits = subReportNode.newReportNode().withMessageTemplate(REACTIVE_LIMITS, REACTIVE_LIMITS).add();
-            subReporterReactiveLimits.newReportNode()
-                    .withMessageTemplate(REACTIVE_LIMITS, REACTIVE_LIMITS)
-                    .withSeverity(TypedValue.INFO_SEVERITY)
-                    .add();
 
             ModificationUtils.getInstance().reportModifications(subReporterReactiveLimits, minMaxReactiveLimitsReports, "minMaxReactiveLimitsCreated", "By range");
         }
@@ -1210,10 +1187,6 @@ public final class ModificationUtils {
                 });
         adder.add();
         ReportNode subReporterReactiveLimits = subReportNode.newReportNode().withMessageTemplate(REACTIVE_LIMITS, REACTIVE_LIMITS).add();
-        subReporterReactiveLimits.newReportNode()
-                .withMessageTemplate(REACTIVE_LIMITS, REACTIVE_LIMITS)
-                .withSeverity(TypedValue.INFO_SEVERITY)
-                .add();
         ModificationUtils.getInstance().reportModifications(subReporterReactiveLimits, pointsReports, "curveReactiveLimitsCreated", "By diagram");
     }
 

--- a/src/main/java/org/gridsuite/modification/server/modifications/ModificationUtils.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/ModificationUtils.java
@@ -482,19 +482,14 @@ public final class ModificationUtils {
                 .build();
     }
 
-    public ReportNode reportModifications(ReportNode subReportNode, List<ReportNode> reports, String subReportNodeKey,
-                                        String subReportNodeDefaultMessage, Map<String, Object> values) {
+    public ReportNode reportModifications(ReportNode reportNode, List<ReportNode> reports, String subReportNodeKey, String subReportNodeMessage) {
         List<ReportNode> validReports = reports.stream().filter(Objects::nonNull).toList();
-        ReportNode modificationSubReportNode = null;
-        if (!validReports.isEmpty() && subReportNode != null) {
-            modificationSubReportNode = subReportNode.newReportNode().withMessageTemplate(subReportNodeKey, subReportNodeDefaultMessage).add();
-            ReportNodeAdder adder = modificationSubReportNode.newReportNode().withMessageTemplate(subReportNodeKey, subReportNodeDefaultMessage).withSeverity(TypedValue.INFO_SEVERITY);
-            for (Map.Entry<String, Object> valueEntry : values.entrySet()) {
-                adder.withUntypedValue(valueEntry.getKey(), valueEntry.getValue().toString());
-            }
-            adder.add();
+        ReportNode subReportNode = null;
+        if (!validReports.isEmpty() && reportNode != null) {
+            // new child report node
+            subReportNode = reportNode.newReportNode().withMessageTemplate(subReportNodeKey, subReportNodeMessage).add();
             for (ReportNode report : validReports) {
-                ReportNodeAdder reportNodeAdder = modificationSubReportNode.newReportNode().withMessageTemplate(report.getMessageKey(), report.getMessageTemplate()).withSeverity(TypedValue.INFO_SEVERITY);
+                ReportNodeAdder reportNodeAdder = subReportNode.newReportNode().withMessageTemplate(report.getMessageKey(), report.getMessageTemplate()).withSeverity(TypedValue.INFO_SEVERITY);
                 for (Map.Entry<String, TypedValue> valueEntry : report.getValues().entrySet()) {
                     reportNodeAdder.withUntypedValue(valueEntry.getKey(), valueEntry.getValue().toString());
                 }
@@ -505,7 +500,7 @@ public final class ModificationUtils {
                 reportNodeAdder.add();
             }
         }
-        return modificationSubReportNode;
+        return subReportNode;
     }
 
     public <T> void applyElementaryModifications(Consumer<T> setter, Supplier<T> getter,
@@ -626,7 +621,7 @@ public final class ModificationUtils {
             createNewConnectivityPosition(connectablePositionAdder, modificationInfos, reports);
         }
         modifyInjectionConnection(modificationInfos, injection, reports);
-        return reportModifications(connectivityReports, reports, "ConnectivityModified", CONNECTIVITY, Map.of());
+        return reportModifications(connectivityReports, reports, "ConnectivityModified", CONNECTIVITY);
     }
 
     private void modifyExistingConnectivityPosition(ConnectablePosition<?> connectablePosition,
@@ -873,7 +868,7 @@ public final class ModificationUtils {
                     .withSeverity(TypedValue.INFO_SEVERITY)
                     .add();
         }
-        reportModifications(subReportNodeReactiveLimits, reports, "curveReactiveLimitsModified", "By diagram", Map.of());
+        reportModifications(subReportNodeReactiveLimits, reports, "curveReactiveLimitsModified", "By diagram");
     }
 
     public void createReactiveCapabilityCurvePoint(ReactiveCapabilityCurveAdder adder,
@@ -983,7 +978,7 @@ public final class ModificationUtils {
                     .withSeverity(TypedValue.INFO_SEVERITY)
                     .add();
         }
-        reportModifications(subReportNodeReactiveLimits, reports, "minMaxReactiveLimitsModified", "By range", Map.of());
+        reportModifications(subReportNodeReactiveLimits, reports, "minMaxReactiveLimitsModified", "By range");
     }
 
     private void modifyExistingActivePowerControl(ActivePowerControl<?> activePowerControl,
@@ -1042,7 +1037,7 @@ public final class ModificationUtils {
                     .withSeverity(TypedValue.INFO_SEVERITY)
                     .add();
         }
-        reportModifications(subReportNodeSetpoints2, reports, "activePowerRegulationModified", "Active power regulation", Map.of());
+        reportModifications(subReportNodeSetpoints2, reports, "activePowerRegulationModified", "Active power regulation");
         return subReportNodeSetpoints2;
     }
 
@@ -1190,7 +1185,7 @@ public final class ModificationUtils {
                     .withSeverity(TypedValue.INFO_SEVERITY)
                     .add();
 
-            ModificationUtils.getInstance().reportModifications(subReporterReactiveLimits, minMaxReactiveLimitsReports, "minMaxReactiveLimitsCreated", "By range", Map.of());
+            ModificationUtils.getInstance().reportModifications(subReporterReactiveLimits, minMaxReactiveLimitsReports, "minMaxReactiveLimitsCreated", "By range");
         }
     }
 
@@ -1219,7 +1214,7 @@ public final class ModificationUtils {
                 .withMessageTemplate(REACTIVE_LIMITS, REACTIVE_LIMITS)
                 .withSeverity(TypedValue.INFO_SEVERITY)
                 .add();
-        ModificationUtils.getInstance().reportModifications(subReporterReactiveLimits, pointsReports, "curveReactiveLimitsCreated", "By diagram", Map.of());
+        ModificationUtils.getInstance().reportModifications(subReporterReactiveLimits, pointsReports, "curveReactiveLimitsCreated", "By diagram");
     }
 
     private void createReactiveCapabilityCurvePoint(ReactiveCapabilityCurveAdder adder,

--- a/src/main/java/org/gridsuite/modification/server/modifications/ModificationUtils.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/ModificationUtils.java
@@ -469,7 +469,7 @@ public final class ModificationUtils {
             T newValue = modification.applyModification(oldValue);
             setter.accept(newValue);
 
-            return buildModificationReportWithIndentation(oldValue, newValue, fieldName, indentationLevel);
+            return buildModificationReport(oldValue, newValue, fieldName, indentationLevel);
         }
         return null;
     }
@@ -526,8 +526,7 @@ public final class ModificationUtils {
         return buildModificationReport(oldValue, newValue, fieldName, 1, TypedValue.INFO_SEVERITY);
     }
 
-    //TODO rename to buildModificationReport()
-    public <T> ReportNode buildModificationReportWithIndentation(T oldValue, T newValue, String fieldName, int indentationLevel) {
+    public <T> ReportNode buildModificationReport(T oldValue, T newValue, String fieldName, int indentationLevel) {
         return buildModificationReport(oldValue, newValue, fieldName, indentationLevel, TypedValue.INFO_SEVERITY);
     }
 

--- a/src/main/java/org/gridsuite/modification/server/modifications/PropertiesUtils.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/PropertiesUtils.java
@@ -24,7 +24,7 @@ public final class PropertiesUtils {
         );
         if (!reportNodes.isEmpty()) {
             ModificationUtils.getInstance().reportModifications(subReportNode, reportNodes,
-                propertiesLabelKey, PROPERTIES, Map.of());
+                propertiesLabelKey, PROPERTIES);
         }
     }
 

--- a/src/main/java/org/gridsuite/modification/server/modifications/TwoWindingsTransformerModification.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/TwoWindingsTransformerModification.java
@@ -141,10 +141,13 @@ public class TwoWindingsTransformerModification extends AbstractBranchModificati
                 .getPhaseTapChanger();
 
         List<ReportNode> phaseTapChangerReports = new ArrayList<>();
-        phaseTapChangerReports.add(ModificationUtils.getInstance().applyElementaryModificationsAndReturnReport(
+        ReportNode regulationModeReport = ModificationUtils.getInstance().applyElementaryModificationsAndReturnReport(
                 isModification ? phaseTapChanger::setRegulationMode : phaseTapChangerAdder::setRegulationMode,
                 isModification ? phaseTapChanger::getRegulationMode : () -> null,
-                phaseTapChangerInfos.getRegulationMode(), "Regulation mode", 1));
+                phaseTapChangerInfos.getRegulationMode(), "Regulation mode", 1);
+        if (regulationModeReport != null) {
+            phaseTapChangerReports.add(regulationModeReport);
+        }
 
         List<ReportNode> regulationReports = new ArrayList<>();
         PhaseTapChanger.RegulationMode regulationMode = isModification ? phaseTapChanger.getRegulationMode() : null;
@@ -199,20 +202,26 @@ public class TwoWindingsTransformerModification extends AbstractBranchModificati
             boolean isModification) {
 
         if (regulationMode != null) {
-            regulationReports.add(ModificationUtils.getInstance().applyElementaryModificationsAndReturnReport(
+            ReportNode regulationReport = ModificationUtils.getInstance().applyElementaryModificationsAndReturnReport(
                     isModification ? phaseTapChanger::setRegulationValue
                             : phaseTapChangerAdder::setRegulationValue,
                     isModification ? phaseTapChanger::getRegulationValue : () -> null,
                     phaseTapChangerInfos.getRegulationValue(),
                     regulationMode.equals(PhaseTapChanger.RegulationMode.CURRENT_LIMITER) ? "Value" : "Flow set point",
-                    2));
+                    2);
+            if (regulationReport != null) {
+                regulationReports.add(regulationReport);
+            }
         }
 
-        regulationReports.add(ModificationUtils.getInstance().applyElementaryModificationsAndReturnReport(
+        ReportNode targetDeadbandReport = ModificationUtils.getInstance().applyElementaryModificationsAndReturnReport(
                 isModification ? phaseTapChanger::setTargetDeadband
                         : phaseTapChangerAdder::setTargetDeadband,
                 isModification ? phaseTapChanger::getTargetDeadband : () -> null,
-                phaseTapChangerInfos.getTargetDeadband(), "Target deadband", 2));
+                phaseTapChangerInfos.getTargetDeadband(), "Target deadband", 2);
+        if (targetDeadbandReport != null) {
+            regulationReports.add(targetDeadbandReport);
+        }
 
         if (isModification) {
             phaseTapChanger.setRegulating(true);
@@ -231,11 +240,14 @@ public class TwoWindingsTransformerModification extends AbstractBranchModificati
         RatioTapChanger ratioTapChanger = isModification ? twt.getRatioTapChanger() : null;
         RatioTapChangerAdder ratioTapChangerAdder = isModification ? null : twt.newRatioTapChanger();
         List<ReportNode> ratioTapChangerReports = new ArrayList<>();
-        ratioTapChangerReports.add(ModificationUtils.getInstance().applyElementaryModificationsAndReturnReport(
+        ReportNode tapChangingReport = ModificationUtils.getInstance().applyElementaryModificationsAndReturnReport(
                 isModification ? ratioTapChanger::setLoadTapChangingCapabilities
                         : ratioTapChangerAdder::setLoadTapChangingCapabilities,
                 isModification ? ratioTapChanger::hasLoadTapChangingCapabilities : () -> null,
-                ratioTapChangerInfos.getLoadTapChangingCapabilities(), "Load tap changing capabilities", 1));
+                ratioTapChangerInfos.getLoadTapChangingCapabilities(), "Load tap changing capabilities", 1);
+        if (tapChangingReport != null) {
+            ratioTapChangerReports.add(tapChangingReport);
+        }
         processRegulating(ratioTapChangerInfos, ratioTapChanger, ratioTapChangerAdder, ratioTapChangerReports, isModification);
 
         List<ReportNode> voltageRegulationReports = new ArrayList<>();
@@ -274,11 +286,14 @@ public class TwoWindingsTransformerModification extends AbstractBranchModificati
             List<ReportNode> ratioTapChangerReports, boolean isModification) {
         if (ratioTapChangerInfos.getRegulating() != null && ratioTapChangerInfos.getRegulating().getValue() != null) {
             boolean regulating = ratioTapChangerInfos.getRegulating().getValue();
-            ratioTapChangerReports.add(ModificationUtils.getInstance().applyElementaryModificationsAndReturnReport(
+            ReportNode voltageRegulationReport = ModificationUtils.getInstance().applyElementaryModificationsAndReturnReport(
                     isModification ? ratioTapChanger::setRegulating
                             : ratioTapChangerAdder::setRegulating,
                     isModification ? ratioTapChanger::isRegulating : () -> null,
-                    ratioTapChangerInfos.getRegulating(), regulating ? "Voltage regulation" : "Fixed ratio", 1));
+                    ratioTapChangerInfos.getRegulating(), regulating ? "Voltage regulation" : "Fixed ratio", 1);
+            if (voltageRegulationReport != null) {
+                ratioTapChangerReports.add(voltageRegulationReport);
+            }
         }
     }
 
@@ -289,19 +304,24 @@ public class TwoWindingsTransformerModification extends AbstractBranchModificati
             List<ReportNode> voltageRegulationReports,
             Network network,
             boolean isModification) {
-        voltageRegulationReports
-                .add(ModificationUtils.getInstance().applyElementaryModificationsAndReturnReport(
+
+        ReportNode targetVoltageReport = ModificationUtils.getInstance().applyElementaryModificationsAndReturnReport(
                         isModification ? ratioTapChanger::setTargetV
                                 : ratioTapChangerAdder::setTargetV,
                         isModification ? ratioTapChanger::getTargetV : () -> null,
-                        ratioTapChangerInfos.getTargetV(), "Target voltage", 2));
+                        ratioTapChangerInfos.getTargetV(), "Target voltage", 2);
+        if (targetVoltageReport != null) {
+            voltageRegulationReports.add(targetVoltageReport);
+        }
 
-        voltageRegulationReports
-                .add(ModificationUtils.getInstance().applyElementaryModificationsAndReturnReport(
-                        isModification ? ratioTapChanger::setTargetDeadband
-                                : ratioTapChangerAdder::setTargetDeadband,
-                        isModification ? ratioTapChanger::getTargetDeadband : () -> null,
-                        ratioTapChangerInfos.getTargetDeadband(), "Target deadband", 2));
+        ReportNode targetDeadbandReport = ModificationUtils.getInstance().applyElementaryModificationsAndReturnReport(
+                isModification ? ratioTapChanger::setTargetDeadband
+                        : ratioTapChangerAdder::setTargetDeadband,
+                isModification ? ratioTapChanger::getTargetDeadband : () -> null,
+                ratioTapChangerInfos.getTargetDeadband(), "Target deadband", 2);
+        if (targetDeadbandReport != null) {
+            voltageRegulationReports.add(targetDeadbandReport);
+        }
 
         processRegulatingTerminal(ratioTapChangerInfos, ratioTapChanger, ratioTapChangerAdder, voltageRegulationReports,
                     network, twt, isModification);
@@ -417,17 +437,23 @@ public class TwoWindingsTransformerModification extends AbstractBranchModificati
             TapChangerAdder<?, ?, ?, ?, ?, ?> tapChangerAdder,
             List<ReportNode> tapChangerReports,
             boolean isModification) {
-        tapChangerReports.add(ModificationUtils.getInstance().applyElementaryModificationsAndReturnReport(
+        ReportNode lowTapPositionReport = ModificationUtils.getInstance().applyElementaryModificationsAndReturnReport(
                 isModification ? tapChanger::setLowTapPosition
                         : tapChangerAdder::setLowTapPosition,
                 isModification ? tapChanger::getLowTapPosition : () -> null,
-                tapChangerModificationInfos.getLowTapPosition(), "Low tap position", 2));
+                tapChangerModificationInfos.getLowTapPosition(), "Low tap position", 2);
+        if (lowTapPositionReport != null) {
+            tapChangerReports.add(lowTapPositionReport);
+        }
 
-        tapChangerReports.add(ModificationUtils.getInstance().applyElementaryModificationsAndReturnReport(
+        ReportNode tapPositionReport = ModificationUtils.getInstance().applyElementaryModificationsAndReturnReport(
                 isModification ? tapChanger::setTapPosition
                         : tapChangerAdder::setTapPosition,
                 isModification ? tapChanger::getTapPosition : () -> null,
-                tapChangerModificationInfos.getTapPosition(), "Tap position", 2));
+                tapChangerModificationInfos.getTapPosition(), "Tap position", 2);
+        if (tapPositionReport != null) {
+            tapChangerReports.add(tapPositionReport);
+        }
 
         // Add steps
         if (tapChangerModificationInfos.getSteps() != null) {

--- a/src/main/java/org/gridsuite/modification/server/modifications/TwoWindingsTransformerModification.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/TwoWindingsTransformerModification.java
@@ -15,7 +15,6 @@ import org.gridsuite.modification.server.dto.*;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import static org.gridsuite.modification.server.NetworkModificationException.Type.TWO_WINDINGS_TRANSFORMER_NOT_FOUND;
 import static org.gridsuite.modification.server.modifications.ModificationUtils.insertReportNode;
@@ -172,8 +171,8 @@ public class TwoWindingsTransformerModification extends AbstractBranchModificati
 
         if (!phaseTapChangerReports.isEmpty() || !regulationReports.isEmpty() || !positionsAndStepsReports.isEmpty()) {
             ReportNode phaseTapChangerSubreporter = ModificationUtils.getInstance().reportModifications(subReportNode,
-                    phaseTapChangerReports, TapChangerType.PHASE.name(), PHASE_TAP_CHANGER_SUBREPORTER_DEFAULT_MESSAGE,
-                    Map.of());
+                    phaseTapChangerReports, TapChangerType.PHASE.name(), PHASE_TAP_CHANGER_SUBREPORTER_DEFAULT_MESSAGE
+            );
             if (phaseTapChangerSubreporter == null) {
                 phaseTapChangerSubreporter = subReportNode.newReportNode()
                         .withMessageTemplate(TapChangerType.PHASE.name(), PHASE_TAP_CHANGER_SUBREPORTER_DEFAULT_MESSAGE)
@@ -185,10 +184,10 @@ public class TwoWindingsTransformerModification extends AbstractBranchModificati
             }
             ModificationUtils.getInstance().reportModifications(phaseTapChangerSubreporter, regulationReports,
                     regulationMode != null ? regulationMode.name() : null,
-                    ModificationUtils.getInstance().formatRegulationModeReport(regulationMode),
-                    Map.of());
+                    ModificationUtils.getInstance().formatRegulationModeReport(regulationMode)
+            );
             ModificationUtils.getInstance().reportModifications(phaseTapChangerSubreporter, positionsAndStepsReports,
-                    "phaseTapChangerPositionsAndStepsModification", "    Tap Changer", Map.of());
+                    "phaseTapChangerPositionsAndStepsModification", "    Tap Changer");
         }
     }
 
@@ -253,7 +252,7 @@ public class TwoWindingsTransformerModification extends AbstractBranchModificati
         if (!ratioTapChangerReports.isEmpty() || !voltageRegulationReports.isEmpty()
                 || !positionsAndStepsReports.isEmpty()) {
             ReportNode ratioTapChangerReporter = ModificationUtils.getInstance().reportModifications(subReporter,
-                    ratioTapChangerReports, TapChangerType.RATIO.name(), RATIO_TAP_CHANGER_SUBREPORTER_DEFAULT_MESSAGE, Map.of());
+                    ratioTapChangerReports, TapChangerType.RATIO.name(), RATIO_TAP_CHANGER_SUBREPORTER_DEFAULT_MESSAGE);
             if (ratioTapChangerReporter == null) {
                 ratioTapChangerReporter = subReporter.newReportNode()
                         .withMessageTemplate(TapChangerType.RATIO.name(), RATIO_TAP_CHANGER_SUBREPORTER_DEFAULT_MESSAGE)
@@ -264,9 +263,9 @@ public class TwoWindingsTransformerModification extends AbstractBranchModificati
                         .add();
             }
             ModificationUtils.getInstance().reportModifications(ratioTapChangerReporter, voltageRegulationReports,
-                    "ratioTapChangerVoltageRegulationModification", "    Voltage regulation", Map.of());
+                    "ratioTapChangerVoltageRegulationModification", "    Voltage regulation");
             ModificationUtils.getInstance().reportModifications(ratioTapChangerReporter, positionsAndStepsReports,
-                    "ratioTapChangerPositionsAndStepsModification", "    Tap Changer", Map.of());
+                    "ratioTapChangerPositionsAndStepsModification", "    Tap Changer");
         }
     }
 

--- a/src/main/java/org/gridsuite/modification/server/modifications/TwoWindingsTransformerModification.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/TwoWindingsTransformerModification.java
@@ -56,19 +56,15 @@ public class TwoWindingsTransformerModification extends AbstractBranchModificati
     protected void modifyCharacteristics(Branch<?> branch, BranchModificationInfos branchModificationInfos, ReportNode subReportNode) {
         TwoWindingsTransformer twoWindingsTransformer = (TwoWindingsTransformer) branch;
         ReportNode characteristicsReporter = subReportNode.newReportNode().withMessageTemplate("characteristics", "Characteristics").add();
-        characteristicsReporter.newReportNode()
-                .withMessageTemplate("characteristicsModification", "Characteristics")
-                .withSeverity(TypedValue.INFO_SEVERITY)
-                .add();
 
         // Branch specific fields
         if (branchModificationInfos.getR() != null && branchModificationInfos.getR().getValue() != null) {
-            insertReportNode(characteristicsReporter, ModificationUtils.getInstance().buildModificationReportWithIndentation(twoWindingsTransformer.getR(),
+            insertReportNode(characteristicsReporter, ModificationUtils.getInstance().buildModificationReport(twoWindingsTransformer.getR(),
                     branchModificationInfos.getR().getValue(), "Series resistance", 1));
             twoWindingsTransformer.setR(branchModificationInfos.getR().getValue());
         }
         if (branchModificationInfos.getX() != null && branchModificationInfos.getX().getValue() != null) {
-            insertReportNode(characteristicsReporter, ModificationUtils.getInstance().buildModificationReportWithIndentation(twoWindingsTransformer.getX(),
+            insertReportNode(characteristicsReporter, ModificationUtils.getInstance().buildModificationReport(twoWindingsTransformer.getX(),
                     branchModificationInfos.getX().getValue(), "Series reactance", 1));
             twoWindingsTransformer.setX(branchModificationInfos.getX().getValue());
         }
@@ -79,7 +75,7 @@ public class TwoWindingsTransformerModification extends AbstractBranchModificati
             // convert reported value from siemens to microsiemens
             double oldMagnetizingConductanceToReport = twoWindingsTransformer.getG() * Math.pow(10, 6);
             double newMagnetizingConductanceToReport = twoWindingsTransformerModificationInfos.getG().getValue() * Math.pow(10, 6);
-            insertReportNode(characteristicsReporter, ModificationUtils.getInstance().buildModificationReportWithIndentation(oldMagnetizingConductanceToReport,
+            insertReportNode(characteristicsReporter, ModificationUtils.getInstance().buildModificationReport(oldMagnetizingConductanceToReport,
                     newMagnetizingConductanceToReport, "Magnetizing conductance", 1));
             twoWindingsTransformer.setG(twoWindingsTransformerModificationInfos.getG().getValue());
         }
@@ -87,22 +83,22 @@ public class TwoWindingsTransformerModification extends AbstractBranchModificati
             // convert reported value from siemens to microsiemens
             double oldMagnetizingSusceptanceToReport = twoWindingsTransformer.getB() * Math.pow(10, 6);
             double newMagnetizingSusceptanceToReport = twoWindingsTransformerModificationInfos.getB().getValue() * Math.pow(10, 6);
-            insertReportNode(characteristicsReporter, ModificationUtils.getInstance().buildModificationReportWithIndentation(oldMagnetizingSusceptanceToReport,
+            insertReportNode(characteristicsReporter, ModificationUtils.getInstance().buildModificationReport(oldMagnetizingSusceptanceToReport,
                             newMagnetizingSusceptanceToReport, "Magnetizing susceptance", 1));
             twoWindingsTransformer.setB(twoWindingsTransformerModificationInfos.getB().getValue());
         }
         if (twoWindingsTransformerModificationInfos.getRatedS() != null && twoWindingsTransformerModificationInfos.getRatedS().getValue() != null) {
-            insertReportNode(characteristicsReporter, ModificationUtils.getInstance().buildModificationReportWithIndentation(twoWindingsTransformer.getRatedS(),
+            insertReportNode(characteristicsReporter, ModificationUtils.getInstance().buildModificationReport(twoWindingsTransformer.getRatedS(),
                             twoWindingsTransformerModificationInfos.getRatedS().getValue(), "Rated nominal power", 1));
             twoWindingsTransformer.setRatedS(twoWindingsTransformerModificationInfos.getRatedS().getValue());
         }
         if (twoWindingsTransformerModificationInfos.getRatedU1() != null && twoWindingsTransformerModificationInfos.getRatedU1().getValue() != null) {
-            insertReportNode(characteristicsReporter, ModificationUtils.getInstance().buildModificationReportWithIndentation(twoWindingsTransformer.getRatedU1(),
+            insertReportNode(characteristicsReporter, ModificationUtils.getInstance().buildModificationReport(twoWindingsTransformer.getRatedU1(),
                     twoWindingsTransformerModificationInfos.getRatedU1().getValue(), "Rated Voltage (Side 1)", 1));
             twoWindingsTransformer.setRatedU1(twoWindingsTransformerModificationInfos.getRatedU1().getValue());
         }
         if (twoWindingsTransformerModificationInfos.getRatedU2() != null && twoWindingsTransformerModificationInfos.getRatedU2().getValue() != null) {
-            insertReportNode(characteristicsReporter, ModificationUtils.getInstance().buildModificationReportWithIndentation(twoWindingsTransformer.getRatedU2(),
+            insertReportNode(characteristicsReporter, ModificationUtils.getInstance().buildModificationReport(twoWindingsTransformer.getRatedU2(),
                     twoWindingsTransformerModificationInfos.getRatedU2().getValue(), "Rated Voltage (Side 2)", 1));
             twoWindingsTransformer.setRatedU2(twoWindingsTransformerModificationInfos.getRatedU2().getValue());
         }
@@ -179,10 +175,6 @@ public class TwoWindingsTransformerModification extends AbstractBranchModificati
             if (phaseTapChangerSubreporter == null) {
                 phaseTapChangerSubreporter = subReportNode.newReportNode()
                         .withMessageTemplate(TapChangerType.PHASE.name(), PHASE_TAP_CHANGER_SUBREPORTER_DEFAULT_MESSAGE)
-                        .add();
-                phaseTapChangerSubreporter.newReportNode()
-                        .withMessageTemplate(TapChangerType.PHASE.name(), PHASE_TAP_CHANGER_SUBREPORTER_DEFAULT_MESSAGE)
-                        .withSeverity(TypedValue.INFO_SEVERITY)
                         .add();
             }
             ModificationUtils.getInstance().reportModifications(phaseTapChangerSubreporter, regulationReports,
@@ -268,10 +260,6 @@ public class TwoWindingsTransformerModification extends AbstractBranchModificati
             if (ratioTapChangerReporter == null) {
                 ratioTapChangerReporter = subReporter.newReportNode()
                         .withMessageTemplate(TapChangerType.RATIO.name(), RATIO_TAP_CHANGER_SUBREPORTER_DEFAULT_MESSAGE)
-                        .add();
-                ratioTapChangerReporter.newReportNode()
-                        .withMessageTemplate(TapChangerType.RATIO.name(), RATIO_TAP_CHANGER_SUBREPORTER_DEFAULT_MESSAGE)
-                        .withSeverity(TypedValue.INFO_SEVERITY)
                         .add();
             }
             ModificationUtils.getInstance().reportModifications(ratioTapChangerReporter, voltageRegulationReports,
@@ -365,10 +353,10 @@ public class TwoWindingsTransformerModification extends AbstractBranchModificati
                 tapChangerAdder.setRegulationTerminal(terminal);
             }
             regulationReports
-                    .add(ModificationUtils.getInstance().buildModificationReportWithIndentation(oldVoltageLevel,
+                    .add(ModificationUtils.getInstance().buildModificationReport(oldVoltageLevel,
                             tapChangerModificationInfos.getRegulatingTerminalVlId().getValue(),
                             "Voltage level", 2));
-            regulationReports.add(ModificationUtils.getInstance().buildModificationReportWithIndentation(oldEquipment,
+            regulationReports.add(ModificationUtils.getInstance().buildModificationReport(oldEquipment,
                     tapChangerModificationInfos.getRegulatingTerminalType().getValue() + ":"
                             + tapChangerModificationInfos.getRegulatingTerminalId().getValue(),
                     "Equipment", 2));

--- a/src/main/java/org/gridsuite/modification/server/modifications/VscCreation.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/VscCreation.java
@@ -155,23 +155,19 @@ public class VscCreation extends AbstractModification {
         ModificationUtils.getInstance().reportModifications(subReportNode, limitsReports, "vscLimits", "Limits");
 
         List<ReportNode> setPointsReports = new ArrayList<>();
-        ReportNode setPointsReporter = subReportNode.newReportNode().withMessageTemplate(VSC_SETPOINTS, SETPOINTS).add();
         setPointsReports.add(ModificationUtils.getInstance().buildCreationReport(modificationInfos.getConvertersMode(), "Converters mode"));
         setPointsReports.add(ModificationUtils.getInstance().buildCreationReport(modificationInfos.getActivePowerSetpoint(), "Active power"));
-        ModificationUtils.getInstance().reportModifications(setPointsReporter, setPointsReports, VSC_SETPOINTS, SETPOINTS);
+        ReportNode setPointsReporter = ModificationUtils.getInstance().reportModifications(subReportNode, setPointsReports, VSC_SETPOINTS, SETPOINTS);
 
         List<ReportNode> angleDroopActivePowerControlReports = new ArrayList<>();
         angleDroopActivePowerControlReports.add(ModificationUtils.getInstance()
                 .createEnabledDisabledReport("angleDroopActivePowerControl", modificationInfos.getAngleDroopActivePowerControl()));
-
         if (modificationInfos.getP0() != null) {
             angleDroopActivePowerControlReports.add(ModificationUtils.getInstance().buildCreationReport(modificationInfos.getP0(), "P0"));
         }
-
         if (modificationInfos.getDroop() != null) {
             angleDroopActivePowerControlReports.add(ModificationUtils.getInstance().buildCreationReport(modificationInfos.getDroop(), "Droop"));
         }
-
         ModificationUtils.getInstance().reportModifications(setPointsReporter, angleDroopActivePowerControlReports, "vscAngleDroop", "Angle droop active power control");
     }
 

--- a/src/main/java/org/gridsuite/modification/server/modifications/VscCreation.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/VscCreation.java
@@ -20,7 +20,6 @@ import org.gridsuite.modification.server.dto.VscCreationInfos;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import static org.gridsuite.modification.server.NetworkModificationException.Type.*;
 
@@ -148,18 +147,18 @@ public class VscCreation extends AbstractModification {
         characteristicsReports.add(ModificationUtils.getInstance().buildCreationReport(modificationInfos.getNominalV(), "DC nominal voltage"));
         characteristicsReports.add(ModificationUtils.getInstance().buildCreationReport(modificationInfos.getR(), "DC resistance"));
         characteristicsReports.add(ModificationUtils.getInstance().buildCreationReport(modificationInfos.getMaxP(), "Pmax"));
-        ModificationUtils.getInstance().reportModifications(subReportNode, characteristicsReports, VSC_CHARACTERISTICS, CHARACTERISTICS, Map.of());
+        ModificationUtils.getInstance().reportModifications(subReportNode, characteristicsReports, VSC_CHARACTERISTICS, CHARACTERISTICS);
 
         List<ReportNode> limitsReports = new ArrayList<>();
         limitsReports.add(ModificationUtils.getInstance().buildCreationReport(modificationInfos.getOperatorActivePowerLimitFromSide1ToSide2(), "Operator active power limit (Side1 -> Side 2)"));
         limitsReports.add(ModificationUtils.getInstance().buildCreationReport(modificationInfos.getOperatorActivePowerLimitFromSide2ToSide1(), "Operator active power limit (Side2 -> Side 1)"));
-        ModificationUtils.getInstance().reportModifications(subReportNode, limitsReports, "vscLimits", "Limits", Map.of());
+        ModificationUtils.getInstance().reportModifications(subReportNode, limitsReports, "vscLimits", "Limits");
 
         List<ReportNode> setPointsReports = new ArrayList<>();
         ReportNode setPointsReporter = subReportNode.newReportNode().withMessageTemplate(VSC_SETPOINTS, SETPOINTS).add();
         setPointsReports.add(ModificationUtils.getInstance().buildCreationReport(modificationInfos.getConvertersMode(), "Converters mode"));
         setPointsReports.add(ModificationUtils.getInstance().buildCreationReport(modificationInfos.getActivePowerSetpoint(), "Active power"));
-        ModificationUtils.getInstance().reportModifications(setPointsReporter, setPointsReports, VSC_SETPOINTS, SETPOINTS, Map.of());
+        ModificationUtils.getInstance().reportModifications(setPointsReporter, setPointsReports, VSC_SETPOINTS, SETPOINTS);
 
         List<ReportNode> angleDroopActivePowerControlReports = new ArrayList<>();
         angleDroopActivePowerControlReports.add(ModificationUtils.getInstance()
@@ -173,7 +172,7 @@ public class VscCreation extends AbstractModification {
             angleDroopActivePowerControlReports.add(ModificationUtils.getInstance().buildCreationReport(modificationInfos.getDroop(), "Droop"));
         }
 
-        ModificationUtils.getInstance().reportModifications(setPointsReporter, angleDroopActivePowerControlReports, "vscAngleDroop", "Angle droop active power control", Map.of());
+        ModificationUtils.getInstance().reportModifications(setPointsReporter, angleDroopActivePowerControlReports, "vscAngleDroop", "Angle droop active power control");
     }
 
     private VscConverterStation createConverterStation(Network network,
@@ -272,7 +271,7 @@ public class VscCreation extends AbstractModification {
         ModificationUtils.getInstance().reportModifications(subReporter,
                 List.of(ModificationUtils.getInstance().buildCreationReport(converterStationCreationInfos.getLossFactor(), "Loss Factor")),
                 "converterStationCharacteristics",
-                CHARACTERISTICS, Map.of());
+                CHARACTERISTICS);
 
         ModificationUtils.getInstance().createReactiveLimits(converterStationCreationInfos, vscConverterStation, subReporter);
 
@@ -302,7 +301,7 @@ public class VscCreation extends AbstractModification {
         ModificationUtils.getInstance().reportModifications(setPointReporter,
                 setPointsVoltageReports,
                 "converterStationSetPointsVoltageRegulation",
-                "Voltage regulation", Map.of());
+                "Voltage regulation");
     }
 
     private void reportConnectivity(ConverterStationCreationInfos converterStationCreationInfos, ReportNode subReportNode) {
@@ -332,6 +331,6 @@ public class VscCreation extends AbstractModification {
                     .withSeverity(TypedValue.INFO_SEVERITY)
                     .build());
         }
-        ModificationUtils.getInstance().reportModifications(subReportNode, connectivityReports, "ConnectivityCreated", "Connectivity", Map.of());
+        ModificationUtils.getInstance().reportModifications(subReportNode, connectivityReports, "ConnectivityCreated", "Connectivity");
     }
 }

--- a/src/main/java/org/gridsuite/modification/server/modifications/VscCreation.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/VscCreation.java
@@ -175,13 +175,13 @@ public class VscCreation extends AbstractModification {
                                                        ConverterStationCreationInfos converterStationCreationInfos,
                                                        ReportNode subReportNode,
                                                        String logFieldName) {
-        ReportNode converterStationReporter = subReportNode.newReportNode().withMessageTemplate("converterStationCreated" + logFieldName, logFieldName).add();
+        ReportNode converterStationReporter = subReportNode.newReportNode().withMessageTemplate("converterStationCreationContainer" + logFieldName, logFieldName).add();
         VoltageLevel voltageLevel = ModificationUtils.getInstance().getVoltageLevel(network, converterStationCreationInfos.getVoltageLevelId());
         VscConverterStation vscConverterStation = voltageLevel.getTopologyKind() == TopologyKind.NODE_BREAKER ?
                 createConverterStationInNodeBreaker(network, voltageLevel, converterStationCreationInfos, converterStationReporter) :
                 createConverterStationInBusBreaker(voltageLevel, converterStationCreationInfos, converterStationReporter);
         converterStationReporter.newReportNode()
-                .withMessageTemplate("converterStationCreated" + logFieldName, "New converter station with id=${id} created")
+                .withMessageTemplate("converterStationCreationLog" + logFieldName, "New converter station with id=${id} created")
                 .withUntypedValue("id", converterStationCreationInfos.getEquipmentId())
                 .withSeverity(TypedValue.INFO_SEVERITY)
                 .add();

--- a/src/main/java/org/gridsuite/modification/server/modifications/VscCreation.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/VscCreation.java
@@ -280,10 +280,6 @@ public class VscCreation extends AbstractModification {
 
     private void reportConverterStationSetPoints(ConverterStationCreationInfos converterStationCreationInfos, ReportNode subReportNode) {
         ReportNode setPointReporter = subReportNode.newReportNode().withMessageTemplate("converterStationSetPoint", SETPOINTS).add();
-        setPointReporter.newReportNode()
-                .withMessageTemplate(SETPOINTS, SETPOINTS)
-                .withSeverity(TypedValue.INFO_SEVERITY)
-                .add();
 
         if (converterStationCreationInfos.getReactivePowerSetpoint() != null) {
             ModificationUtils.getInstance().reportElementaryCreation(setPointReporter,

--- a/src/main/java/org/gridsuite/modification/server/modifications/VscModification.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/VscModification.java
@@ -107,17 +107,20 @@ public class VscModification extends AbstractModification {
         characteristics(hvdcLine, modificationInfos, subReportNode);
 
         // Set Points
-        //  Set Points
         List<ReportNode> setPointsReports = setPoints(hvdcLine);
-        //  hvdc droop
+        // Hvdc droop
         List<ReportNode> droopReports = hvdcAngleDroopActivePowerControlAdder(hvdcLine);
 
         if (!setPointsReports.isEmpty() || !droopReports.isEmpty()) {
-            ReportNode setPointsReport = subReportNode.newReportNode().withMessageTemplate(VSC_SETPOINTS, SETPOINTS).add();
+            ReportNode setPointsReport = null;
             if (!setPointsReports.isEmpty()) {
-                ModificationUtils.getInstance().reportModifications(setPointsReport, setPointsReports, VSC_SETPOINTS, SETPOINTS);
+                setPointsReport = ModificationUtils.getInstance().reportModifications(subReportNode, setPointsReports, VSC_SETPOINTS, SETPOINTS);
             }
             if (!droopReports.isEmpty()) {
+                if (setPointsReport == null) {
+                    setPointsReport = subReportNode.newReportNode().withMessageTemplate(VSC_SETPOINTS, SETPOINTS).add();
+                }
+                // Hvdc droop logs are in a subReport of Set Points
                 ModificationUtils.getInstance().reportModifications(setPointsReport, droopReports, "vscAngleDroop", "Angle droop active power control");
             }
         }

--- a/src/main/java/org/gridsuite/modification/server/modifications/VscModification.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/VscModification.java
@@ -115,10 +115,10 @@ public class VscModification extends AbstractModification {
         if (!setPointsReports.isEmpty() || !droopReports.isEmpty()) {
             ReportNode setPointsReport = subReportNode.newReportNode().withMessageTemplate(VSC_SETPOINTS, SETPOINTS).add();
             if (!setPointsReports.isEmpty()) {
-                ModificationUtils.getInstance().reportModifications(setPointsReport, setPointsReports, VSC_SETPOINTS, SETPOINTS, Map.of());
+                ModificationUtils.getInstance().reportModifications(setPointsReport, setPointsReports, VSC_SETPOINTS, SETPOINTS);
             }
             if (!droopReports.isEmpty()) {
-                ModificationUtils.getInstance().reportModifications(setPointsReport, droopReports, "vscAngleDroop", "Angle droop active power control", Map.of());
+                ModificationUtils.getInstance().reportModifications(setPointsReport, droopReports, "vscAngleDroop", "Angle droop active power control");
             }
         }
 
@@ -149,7 +149,7 @@ public class VscModification extends AbstractModification {
             characteristicsReportsContainer.add(ModificationUtils.getInstance().applyAndBuildModificationReport(hvdcLine::setMaxP, hvdcLine::getMaxP, modificationInfos.getMaxP(), "Power max"));
         }
         if (!characteristicsReportsContainer.isEmpty()) {
-            ModificationUtils.getInstance().reportModifications(subReportNode, characteristicsReportsContainer, VSC_CHARACTERISTICS, CHARACTERISTICS, Map.of());
+            ModificationUtils.getInstance().reportModifications(subReportNode, characteristicsReportsContainer, VSC_CHARACTERISTICS, CHARACTERISTICS);
         }
     }
 
@@ -179,7 +179,7 @@ public class VscModification extends AbstractModification {
             }
         }
         if (!reports.isEmpty()) {
-            ModificationUtils.getInstance().reportModifications(subReportNode, reports, "vscLimits", "Limits", Map.of());
+            ModificationUtils.getInstance().reportModifications(subReportNode, reports, "vscLimits", "Limits");
         }
     }
 
@@ -296,7 +296,7 @@ public class VscModification extends AbstractModification {
 
         if (!characteristicReports.isEmpty()) {
             ModificationUtils.getInstance().reportModifications(converterStationReportNode,
-                characteristicReports, "Characteristics", "Characteristics", Map.of());
+                characteristicReports, "Characteristics", "Characteristics");
         }
 
         // set points
@@ -317,7 +317,7 @@ public class VscModification extends AbstractModification {
         }
         if (!setPointsReports.isEmpty()) {
             ModificationUtils.getInstance().reportModifications(converterStationReportNode,
-                setPointsReports, SETPOINTS, SETPOINTS, Map.of());
+                setPointsReports, SETPOINTS, SETPOINTS);
         }
 
         // limits


### PR DESCRIPTION
With https://github.com/gridsuite/gridstudy-app/pull/2234 we display all report nodes (report tree on left side) also as logs (messages on right side).

Then we have to remove all logs in the back created only to show these report nodes.