### PR TITLE
Fix all shards have failed on filter deletion

### DIFF
--- a/src/main/java/org/gridsuite/modification/server/elasticsearch/EquipmentInfosService.java
+++ b/src/main/java/org/gridsuite/modification/server/elasticsearch/EquipmentInfosService.java
@@ -61,7 +61,7 @@ public class EquipmentInfosService {
     public void deleteEquipmentInfosList(@NonNull List<String> equipmentIds, @NonNull UUID networkUuid, @NonNull String variantId) {
         Lists.partition(equipmentIds, partitionSize)
                 .parallelStream()
-                .forEach(equipmentIdsSubList -> equipmentInfosRepository.deleteByIdInAndNetworkUuidAndVariantId(equipmentIdsSubList, networkUuid, variantId));
+                .forEach(ids -> equipmentInfosRepository.deleteByIdInAndNetworkUuidAndVariantId(ids, networkUuid, variantId));
     }
 
     public void deleteVariants(@NonNull UUID networkUuid, List<String> variantIds) {

--- a/src/main/java/org/gridsuite/modification/server/elasticsearch/EquipmentInfosService.java
+++ b/src/main/java/org/gridsuite/modification/server/elasticsearch/EquipmentInfosService.java
@@ -59,7 +59,9 @@ public class EquipmentInfosService {
     }
 
     public void deleteEquipmentInfosList(@NonNull List<String> equipmentIds, @NonNull UUID networkUuid, @NonNull String variantId) {
-        equipmentInfosRepository.deleteByIdInAndNetworkUuidAndVariantId(equipmentIds, networkUuid, variantId);
+        Lists.partition(equipmentIds, partitionSize)
+                .parallelStream()
+                .forEach(equipmentIdsSubList -> equipmentInfosRepository.deleteByIdInAndNetworkUuidAndVariantId(equipmentIdsSubList, networkUuid, variantId));
     }
 
     public void deleteVariants(@NonNull UUID networkUuid, List<String> variantIds) {
@@ -88,8 +90,8 @@ public class EquipmentInfosService {
         );
     }
 
-    public List<EquipmentInfos> findEquipmentInfosList(List<String> equipmentIds, UUID networkUuid, String variantId) {
-        return equipmentInfosRepository.findByIdInAndNetworkUuidAndVariantId(equipmentIds, networkUuid, variantId);
+    public List<EquipmentInfos> findEquipmentInfosList(UUID networkUuid, String variantId) {
+        return equipmentInfosRepository.findAllByNetworkUuidAndVariantId(networkUuid, variantId);
     }
 
     public void deleteAll() {

--- a/src/main/java/org/gridsuite/modification/server/modifications/NetworkStoreListener.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/NetworkStoreListener.java
@@ -245,8 +245,7 @@ public class NetworkStoreListener implements NetworkListener {
 
     private void flushEquipmentInfos() {
         String variantId = network.getVariantManager().getWorkingVariantId();
-        Set<String> presentEquipmentDeletionsIds = equipmentInfosService.findEquipmentInfosList(
-                deletedEquipments.stream().map(EquipmentInfosToDelete::id).toList(),
+        Set<String> existingEquipmentIds = equipmentInfosService.findEquipmentInfosList(
                 networkUuid,
                 variantId
         ).stream().map(EquipmentInfos::getId).collect(Collectors.toSet());
@@ -254,7 +253,7 @@ public class NetworkStoreListener implements NetworkListener {
         List<String> equipmentDeletionsIds = new ArrayList<>();
         List<TombstonedEquipmentInfos> tombstonedEquipmentInfos = new ArrayList<>();
         deletedEquipments.forEach(deletedEquipment -> {
-            if (presentEquipmentDeletionsIds.contains(deletedEquipment.id())) {
+            if (existingEquipmentIds.contains(deletedEquipment.id())) {
                 equipmentDeletionsIds.add(deletedEquipment.id());
             }
             // add only allowed equipments types to be indexed to tombstonedEquipmentInfos


### PR DESCRIPTION
On a filter deletion with a lot of things to delete (and current ES local deployment), ES returns a "All shards have failed" error. If you want it to return a response, you'll need to increase ES memory.
For example if you delete all Spain substations (6000 identifiables to delete), you'll have a "All shards have failed" and the modification will fail.
This is still slow but with this fix, the modification succeeds. Performance improvement will be done in a separate PR in the network store that will batch delete identifiables (instead of one by one).
I was able to delete all french substations with this fix (130835 identifiables to delete !!). Everything works fine in the network modification server except that it takes 7 minutes to delete for the network-store-client. 
What this fix does is that instead of doing a IN in elastic search (that is not used in the end as we check for existence later), it simply does a WHERE to get all the existing identifiables in ES for this network (networkuuid/variantnum) which cost a lot less.

To be consistent with other methods in the EquipmentInfosService, we batch the delete with the same mechanism as other methods (like save). With filter deletion, we can have a lot of identifiables to delete (like 130000 if you delete french substations) but there mostly not stored in ES as we only store identifiables that are not in the initial variant.