### PR TITLE
Revert "Fix all shards have failed on filter deletion"

### DIFF
--- a/src/main/java/org/gridsuite/modification/server/elasticsearch/EquipmentInfosService.java
+++ b/src/main/java/org/gridsuite/modification/server/elasticsearch/EquipmentInfosService.java
@@ -59,9 +59,7 @@ public class EquipmentInfosService {
     }
 
     public void deleteEquipmentInfosList(@NonNull List<String> equipmentIds, @NonNull UUID networkUuid, @NonNull String variantId) {
-        Lists.partition(equipmentIds, partitionSize)
-                .parallelStream()
-                .forEach(ids -> equipmentInfosRepository.deleteByIdInAndNetworkUuidAndVariantId(ids, networkUuid, variantId));
+        equipmentInfosRepository.deleteByIdInAndNetworkUuidAndVariantId(equipmentIds, networkUuid, variantId);
     }
 
     public void deleteVariants(@NonNull UUID networkUuid, List<String> variantIds) {
@@ -90,8 +88,8 @@ public class EquipmentInfosService {
         );
     }
 
-    public List<EquipmentInfos> findEquipmentInfosList(UUID networkUuid, String variantId) {
-        return equipmentInfosRepository.findAllByNetworkUuidAndVariantId(networkUuid, variantId);
+    public List<EquipmentInfos> findEquipmentInfosList(List<String> equipmentIds, UUID networkUuid, String variantId) {
+        return equipmentInfosRepository.findByIdInAndNetworkUuidAndVariantId(equipmentIds, networkUuid, variantId);
     }
 
     public void deleteAll() {

--- a/src/main/java/org/gridsuite/modification/server/modifications/NetworkStoreListener.java
+++ b/src/main/java/org/gridsuite/modification/server/modifications/NetworkStoreListener.java
@@ -245,7 +245,8 @@ public class NetworkStoreListener implements NetworkListener {
 
     private void flushEquipmentInfos() {
         String variantId = network.getVariantManager().getWorkingVariantId();
-        Set<String> existingEquipmentIds = equipmentInfosService.findEquipmentInfosList(
+        Set<String> presentEquipmentDeletionsIds = equipmentInfosService.findEquipmentInfosList(
+                deletedEquipments.stream().map(EquipmentInfosToDelete::id).toList(),
                 networkUuid,
                 variantId
         ).stream().map(EquipmentInfos::getId).collect(Collectors.toSet());
@@ -253,7 +254,7 @@ public class NetworkStoreListener implements NetworkListener {
         List<String> equipmentDeletionsIds = new ArrayList<>();
         List<TombstonedEquipmentInfos> tombstonedEquipmentInfos = new ArrayList<>();
         deletedEquipments.forEach(deletedEquipment -> {
-            if (existingEquipmentIds.contains(deletedEquipment.id())) {
+            if (presentEquipmentDeletionsIds.contains(deletedEquipment.id())) {
                 equipmentDeletionsIds.add(deletedEquipment.id());
             }
             // add only allowed equipments types to be indexed to tombstonedEquipmentInfos


### PR DESCRIPTION
Reverts gridsuite/network-modification-server#578
It seems to lead to issues if you have modifications that affect a lot of identifiables (voltage init + generation dispatch + ...).
If there are more than 10000 modified/created identifiables, you can't retrieve the results. You'll get an error about the max result window (https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html, see index.max_result_window).
We'll need to fix it another way, batching (delete/find)? 