### PR TITLE
Fix byFilter deletion network impacts reduction

### DIFF
--- a/src/test/java/org/gridsuite/modification/server/modifications/byfilterdeletion/AbstractByFilterDeletionTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/byfilterdeletion/AbstractByFilterDeletionTest.java
@@ -30,6 +30,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 abstract class AbstractByFilterDeletionTest extends AbstractNetworkModificationTest {
     protected static final UUID FILTER_ID_1 = UUID.randomUUID();
     protected static final UUID FILTER_ID_2 = UUID.randomUUID();
+    protected static final UUID FILTER_ID_3 = UUID.randomUUID();
+
     protected static final String EQUIPMENT_WRONG_ID_1 = "wrongId1";
 
     protected abstract IdentifiableType getIdentifiableType();
@@ -149,10 +151,15 @@ abstract class AbstractByFilterDeletionTest extends AbstractNetworkModificationT
                 .name("filter2")
                 .build();
 
+        var filter3 = FilterInfos.builder()
+                .id(FILTER_ID_3)
+                .name("filter3")
+                .build();
+
         return ByFilterDeletionInfos.builder()
                 .stashed(false)
                 .equipmentType(getIdentifiableType())
-                .filters(List.of(filter1, filter2))
+                .filters(List.of(filter1, filter2, filter3))
                 .build();
     }
 

--- a/src/test/java/org/gridsuite/modification/server/modifications/byfilterdeletion/EquipmentByFilterDeletionTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/byfilterdeletion/EquipmentByFilterDeletionTest.java
@@ -13,6 +13,7 @@ import org.gridsuite.filter.AbstractFilter;
 import org.gridsuite.filter.identifierlistfilter.IdentifierListFilter;
 import org.gridsuite.filter.identifierlistfilter.IdentifierListFilterEquipmentAttributes;
 import org.gridsuite.filter.utils.EquipmentType;
+import org.gridsuite.modification.server.impacts.AbstractBaseImpact;
 import org.gridsuite.modification.server.service.FilterService;
 import org.gridsuite.modification.server.utils.NetworkCreation;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,6 +23,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.gridsuite.modification.server.impacts.TestImpactUtils.createCollectionElementImpact;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -31,6 +34,9 @@ class EquipmentByFilterDeletionTest extends AbstractByFilterDeletionTest {
     private static final String LOAD_ID_2 = "load2";
     private static final String LOAD_ID_3 = "load3";
     private static final String LOAD_ID_4 = "load4";
+    private static final String LOAD_ID_7 = "load7";
+    private static final String LOAD_ID_11 = "load11";
+    private static final String LOAD_ID_12 = "load12";
 
     @BeforeEach
     void specificSetUp() {
@@ -49,6 +55,9 @@ class EquipmentByFilterDeletionTest extends AbstractByFilterDeletionTest {
         assertNull(getNetwork().getLoad(LOAD_ID_2));
         assertNull(getNetwork().getLoad(LOAD_ID_3));
         assertNull(getNetwork().getLoad(LOAD_ID_4));
+        assertNull(getNetwork().getLoad(LOAD_ID_7));
+        assertNull(getNetwork().getLoad(LOAD_ID_11));
+        assertNull(getNetwork().getLoad(LOAD_ID_12));
     }
 
     @Override
@@ -57,6 +66,9 @@ class EquipmentByFilterDeletionTest extends AbstractByFilterDeletionTest {
         assertNotNull(getNetwork().getLoad(LOAD_ID_2));
         assertNotNull(getNetwork().getLoad(LOAD_ID_3));
         assertNotNull(getNetwork().getLoad(LOAD_ID_4));
+        assertNotNull(getNetwork().getLoad(LOAD_ID_7));
+        assertNotNull(getNetwork().getLoad(LOAD_ID_11));
+        assertNotNull(getNetwork().getLoad(LOAD_ID_12));
     }
 
     @Override
@@ -84,6 +96,16 @@ class EquipmentByFilterDeletionTest extends AbstractByFilterDeletionTest {
             .filterEquipmentsAttributes(List.of(new IdentifierListFilterEquipmentAttributes(LOAD_ID_3, null),
                 new IdentifierListFilterEquipmentAttributes(LOAD_ID_4, null)))
             .build();
-        return List.of(filter1, filter2);
+        IdentifierListFilter filter3 = IdentifierListFilter.builder().id(FILTER_ID_3).modificationDate(new Date()).equipmentType(EquipmentType.LOAD)
+            .filterEquipmentsAttributes(List.of(new IdentifierListFilterEquipmentAttributes(LOAD_ID_7, null),
+                new IdentifierListFilterEquipmentAttributes(LOAD_ID_11, null),
+                new IdentifierListFilterEquipmentAttributes(LOAD_ID_12, null)))
+            .build();
+        return List.of(filter1, filter2, filter3);
+    }
+
+    @Override
+    protected void assertResultImpacts(List<AbstractBaseImpact> impacts) {
+        assertThat(impacts).containsExactly(createCollectionElementImpact(IdentifiableType.SUBSTATION));
     }
 }

--- a/src/test/java/org/gridsuite/modification/server/utils/NetworkCreation.java
+++ b/src/test/java/org/gridsuite/modification/server/utils/NetworkCreation.java
@@ -435,6 +435,18 @@ public final class NetworkCreation {
         createSwitch(v32, "v32d1", "v32d1", SwitchKind.DISCONNECTOR, true, false, false, 0, 2);
         createSwitch(v32, "v32d2", "v32d2", SwitchKind.DISCONNECTOR, true, false, false, 1, 3);
 
+        Substation s4 = createSubstation(network, "s4", "s4", Country.FR);
+        VoltageLevel v41 = createVoltageLevel(s4, "v41", "v41", TopologyKind.NODE_BREAKER, 450.0);
+        createBusBarSection(v41, "7.1", "7.1", 0);
+        createLoad(v41, "load11", "load11", 1, 42.1, 1.0, "cn0", 3, ConnectablePosition.Direction.TOP);
+        createSwitch(v41, "v41d1", "v41d1", SwitchKind.DISCONNECTOR, true, false, false, 0, 1);
+
+        Substation s5 = createSubstation(network, "s5", "s5", Country.FR);
+        VoltageLevel v51 = createVoltageLevel(s5, "v51", "v51", TopologyKind.NODE_BREAKER, 450.0);
+        createBusBarSection(v51, "8.1", "8.1", 0);
+        createLoad(v51, "load12", "load12", 1, 42.1, 1.0, "cn0", 3, ConnectablePosition.Direction.TOP);
+        createSwitch(v51, "v51d1", "v51d1", SwitchKind.DISCONNECTOR, true, false, false, 0, 1);
+
         network.getVariantManager().setWorkingVariant(VariantManagerConstants.INITIAL_VARIANT_ID);
         network.getVariantManager().cloneVariant(VariantManagerConstants.INITIAL_VARIANT_ID, VARIANT_ID);
 


### PR DESCRIPTION
Return a unique substation collection impact (`allNetworkImpacted`) when the number of substation containing an equipment deletion is upper or equal to `collectionThreshold`