### PR TITLE
Upgrade temporarily powsybl-core-version forgotten on dependencies upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,8 @@
         <liquibase-hibernate-package>org.gridsuite.modification.server</liquibase-hibernate-package>
         <sonar.coverage.exclusions>**/migration/**/*</sonar.coverage.exclusions>
         <network-modification.version>0.6.1</network-modification.version>
+        <!-- FIXME: powsybl-network-store modules'version is overloaded in the dependencies section.The overloads and this property below have to be removed at next powsybl-ws-dependencies.version upgrade -->
+        <powsybl-core.version>6.6.1</powsybl-core.version>
     </properties>
 
     <build>
@@ -125,6 +127,8 @@
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-iidm-modification</artifactId>
+            <!-- FIXME: powsybl-network-store modules'version is overloaded in the dependencies section.The overloads and this property below have to be removed at next powsybl-ws-dependencies.version upgrade -->
+            <version>${powsybl-core.version}</version>
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>


### PR DESCRIPTION
In version 6.6.0, there are issues with deletions (when deleting all substations of the network for example). 
6.6.1 contains a fix for deletions.