### PR TITLE
Add side info if necessary to the report while validating update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <db-util.version>1.0.5</db-util.version>
         <mockwebserver3.version>5.0.0-alpha.14</mockwebserver3.version>
         <!-- TODO network-modification.version remove when migration powsybl -->
-        <network-modification.version>0.20.0</network-modification.version>
+        <network-modification.version>0.21.0-SNAPSHOT</network-modification.version>
         <liquibase-hibernate-package>org.gridsuite.modification.server</liquibase-hibernate-package>
         <sonar.coverage.exclusions>**/migration/**/*</sonar.coverage.exclusions>
         <sonar.organization>gridsuite</sonar.organization>

--- a/src/test/java/org/gridsuite/modification/server/modifications/BatteryModificationTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/BatteryModificationTest.java
@@ -12,6 +12,7 @@ import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.ReactiveCapabilityCurve;
 import com.powsybl.iidm.network.ReactiveLimitsKind;
 import com.powsybl.iidm.network.extensions.ActivePowerControl;
+import org.gridsuite.modification.NetworkModificationException;
 import org.gridsuite.modification.dto.*;
 import org.gridsuite.modification.server.dto.NetworkModificationsResult;
 import org.gridsuite.modification.server.utils.NetworkCreation;
@@ -28,8 +29,7 @@ import java.util.stream.IntStream;
 import static org.gridsuite.modification.server.report.NetworkModificationServerReportResourceBundle.ERROR_MESSAGE_KEY;
 import static org.gridsuite.modification.server.utils.TestUtils.assertLogMessage;
 import static org.gridsuite.modification.server.utils.assertions.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -350,5 +350,15 @@ class BatteryModificationTest extends AbstractInjectionModificationTest {
     @Test
     void testConnection() throws Exception {
         assertChangeConnectionState(getNetwork().getBattery("v3Battery"), true);
+    }
+
+    @Test
+    void testConnectionError() {
+        getNetwork().getSwitch("v3dBattery").setOpen(true);
+        BatteryModificationInfos batteryModificationInfos = new BatteryModificationInfos();
+        batteryModificationInfos.setEquipmentId("v3Battery");
+        batteryModificationInfos.setTerminalConnected(new AttributeModification<>(true, OperationType.SET));
+        String message = assertThrows(NetworkModificationException.class, () -> batteryModificationInfos.toModification().apply(getNetwork())).getMessage();
+        assertEquals("INJECTION_MODIFICATION_ERROR : Could not connect equipment 'v3Battery'", message);
     }
 }

--- a/src/test/java/org/gridsuite/modification/server/modifications/TwoWindingsTransformerModificationTest.java
+++ b/src/test/java/org/gridsuite/modification/server/modifications/TwoWindingsTransformerModificationTest.java
@@ -824,7 +824,7 @@ class TwoWindingsTransformerModificationTest extends AbstractNetworkModification
         changeConnectionState(getNetwork().getTwoWindingsTransformer("trf2"), TwoSides.ONE, true, true, null);
         changeConnectionState(getNetwork().getTwoWindingsTransformer("trf2"), TwoSides.ONE, true, false, null);
         changeConnectionState(getNetwork().getTwoWindingsTransformer("trf2"), TwoSides.TWO, true, true, null);
-        changeConnectionState(getNetwork().getTwoWindingsTransformer("trf2"), TwoSides.TWO, true, false, "Could not disconnect equipment 'trf2'");
+        changeConnectionState(getNetwork().getTwoWindingsTransformer("trf2"), TwoSides.TWO, true, false, "Could not disconnect equipment 'trf2' on side 2");
     }
 
     private void changeConnectionState(TwoWindingsTransformer existingEquipment, TwoSides side, boolean actualState, boolean expectedState, String errorMessage) throws Exception {


### PR DESCRIPTION
Report the use of the network-modification library in its 0.21-SNAPSHOT version in network-modification-server. To upade later.