### PR TITLE
Add line segment position column to keep order in line modifications

### DIFF
--- a/src/main/java/org/gridsuite/modification/server/entities/equipment/creation/LineCreationEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/equipment/creation/LineCreationEntity.java
@@ -43,9 +43,11 @@ public class LineCreationEntity extends BranchCreationEntity {
 
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinTable(
+        name = "line_creation_line_segments",
         joinColumns = @JoinColumn(name = "line_id"), foreignKey = @ForeignKey(name = "line_id_fk"),
         inverseJoinColumns = @JoinColumn(name = "line_segments_id"), inverseForeignKey = @ForeignKey(name = "line_segments_id_fk"),
         uniqueConstraints = @UniqueConstraint(name = "line_creation_line_segments_uk", columnNames = {"line_segments_id"}))
+    @OrderColumn(name = "pos_line_segments")
     private List<LineSegmentEntity> lineSegments;
 
     public LineCreationEntity(LineCreationInfos lineCreationInfos) {

--- a/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/LineModificationEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/equipment/modification/LineModificationEntity.java
@@ -66,6 +66,7 @@ public class LineModificationEntity extends BranchModificationEntity {
         joinColumns = @JoinColumn(name = "line_id"), foreignKey = @ForeignKey(name = "line_modification_id_fk"),
         inverseJoinColumns = @JoinColumn(name = "line_segments_id"), inverseForeignKey = @ForeignKey(name = "line_segments_id_modification_fk"),
         uniqueConstraints = @UniqueConstraint(name = "line_modification_line_segments_uk", columnNames = {"line_segments_id"}))
+    @OrderColumn(name = "pos_line_segments")
     private List<LineSegmentEntity> lineSegments;
 
     public LineModificationEntity(LineModificationInfos lineModificationInfos) {

--- a/src/main/resources/db/changelog/changesets/changelog_20260415T134200Z.xml
+++ b/src/main/resources/db/changelog/changesets/changelog_20260415T134200Z.xml
@@ -4,10 +4,48 @@
         <addColumn tableName="line_modification_line_segments">
             <column name="pos_line_segments" type="INT"/>
         </addColumn>
+        <!-- Backfill existing rows with deterministic per-line indexes (adjust ORDER BY if a better historical key exists). -->
+        <sql dbms="postgresql">
+            WITH ranked AS (
+                SELECT line_id, line_segments_id,
+                       ROW_NUMBER() OVER (PARTITION BY line_id ORDER BY line_segments_id) - 1 AS pos
+                FROM line_modification_line_segments
+            )
+            UPDATE line_modification_line_segments t
+            SET pos_line_segments = r.pos
+                FROM ranked r
+            WHERE t.line_id = r.line_id
+              AND t.line_segments_id = r.line_segments_id;
+        </sql>
+        <addNotNullConstraint tableName="line_modification_line_segments"
+                              columnName="pos_line_segments"
+                              columnDataType="INT"/>
+        <addUniqueConstraint tableName="line_modification_line_segments"
+                             columnNames="line_id,pos_line_segments"
+                             constraintName="line_modification_line_segments_pos_uk"/>
     </changeSet>
+
     <changeSet author="elcheikhbas (generated)" id="20260415T134200Z-2">
         <addColumn tableName="line_creation_line_segments">
             <column name="pos_line_segments" type="INT" />
         </addColumn>
+        <sql dbms="postgresql">
+            WITH ranked AS (
+                SELECT line_id, line_segments_id,
+                       ROW_NUMBER() OVER (PARTITION BY line_id ORDER BY line_segments_id) - 1 AS pos
+                FROM line_creation_line_segments
+            )
+            UPDATE line_creation_line_segments t
+            SET pos_line_segments = r.pos
+                FROM ranked r
+            WHERE t.line_id = r.line_id
+              AND t.line_segments_id = r.line_segments_id;
+        </sql>
+        <addNotNullConstraint tableName="line_creation_line_segments"
+                              columnName="pos_line_segments"
+                              columnDataType="INT"/>
+        <addUniqueConstraint tableName="line_creation_line_segments"
+                             columnNames="line_id,pos_line_segments"
+                             constraintName="line_creation_line_segments_pos_uk"/>
     </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changesets/changelog_20260415T134200Z.xml
+++ b/src/main/resources/db/changelog/changesets/changelog_20260415T134200Z.xml
@@ -1,0 +1,13 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet author="elcheikhbas (generated)" id="20260415T134200Z-1">
+        <addColumn tableName="line_modification_line_segments">
+            <column name="pos_line_segments" type="INT"/>
+        </addColumn>
+    </changeSet>
+    <changeSet author="elcheikhbas (generated)" id="20260415T134200Z-2">
+        <addColumn tableName="line_creation_line_segments">
+            <column name="pos_line_segments" type="INT" />
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -468,3 +468,6 @@ databaseChangeLog:
   - include:
       file: changesets/changelog_20260413T082023Z.xml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/changelog_20260415T134200Z.xml
+      relativeToChangelogFile: true


### PR DESCRIPTION
## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->

Add order column in line segments tables to preserve same insertion order.
