### PR TITLE
limit reordering during assembling

### DIFF
--- a/src/main/java/org/gridsuite/modification/server/entities/ModificationGroupEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/ModificationGroupEntity.java
@@ -51,9 +51,14 @@ public class ModificationGroupEntity extends AbstractManuallyAssignedIdentifierE
 
     public void setModifications(List<ModificationEntity> modifications) {
         this.modifications = modifications;
-        for (int i = 0; i < modifications.size(); i++) {
-            modifications.get(i).setModificationsOrder(i);
-            modifications.get(i).setGroup(this);
+        for (ModificationEntity modification : modifications) {
+            modification.setGroup(this);
+        }
+        // the unstashed modifications have to be reordered
+        List<ModificationEntity> unstashedModifications = modifications.stream()
+                .filter(m -> !m.getStashed()).toList();
+        for (int i = 0; i < unstashedModifications.size(); i++) {
+            unstashedModifications.get(i).setModificationsOrder(i);
         }
     }
 }

--- a/src/main/java/org/gridsuite/modification/server/repositories/NetworkModificationRepository.java
+++ b/src/main/java/org/gridsuite/modification/server/repositories/NetworkModificationRepository.java
@@ -1012,12 +1012,12 @@ public class NetworkModificationRepository {
                 .filter(Objects::nonNull)
                 .findFirst()
                 .orElse(null);
+        List<ModificationEntity> groupModifications = null;
         if (originGroup != null) {
-            List<ModificationEntity> originGroupModifications = originGroup.getModifications();
-            originGroupModifications.removeIf(mod -> assembledModificationsUuids.contains(mod.getId()));
-            originGroup.setModifications(originGroupModifications);
-            assembledModifications.forEach(modificationEntity -> modificationEntity.setGroup(null));
+            groupModifications = originGroup.getModifications();
+            groupModifications.removeIf(mod -> assembledModificationsUuids.contains(mod.getId()));
         }
+        assembledModifications.forEach(modificationEntity -> modificationEntity.setGroup(null));
         // 2. cleans the composites whose submodifications are assembled into a new one
         for (ModificationEntity assembledModification : assembledModifications.stream().filter(mod -> mod.getGroup() == null).toList()) {
             UUID compositeUuid = modificationRepository.findCompositeIdByContainedModificationId(assembledModification.getId());
@@ -1045,15 +1045,21 @@ public class NetworkModificationRepository {
         newCompositeEntity.setModifications(assembledModifications);
         // put the new composite in the target group or composite
         if (targetGroup != null) {
-            List<ModificationEntity> modifications = targetGroup.getModifications();
-            modifications.add(targetIndex, newCompositeEntity);
-            targetGroup.setModifications(modifications);
+            if (groupModifications == null) {
+                groupModifications = targetGroup.getModifications();
+            }
+            groupModifications.add(targetIndex, newCompositeEntity);
         } else if (targetComposite != null) {
             List<ModificationEntity> modifications = targetComposite.getModifications();
             modifications.add(targetIndex, newCompositeEntity);
             for (int i = 0; i < targetComposite.getModifications().size(); i++) {
                 targetComposite.getModifications().get(i).setModificationsOrder(i);
             }
+        }
+
+        // if the group has been edited :
+        if (groupModifications != null) {
+            targetGroup.setModifications(groupModifications);
         }
 
         return modificationRepository.save(newCompositeEntity);

--- a/src/main/java/org/gridsuite/modification/server/repositories/NetworkModificationRepository.java
+++ b/src/main/java/org/gridsuite/modification/server/repositories/NetworkModificationRepository.java
@@ -995,9 +995,9 @@ public class NetworkModificationRepository {
         final UUID firstModifUuid = assembledModificationsUuids.getFirst();
         final ModificationEntity firstModificationEntity = getModificationEntity(firstModifUuid);
         final int targetIndex = firstModificationEntity.getModificationsOrder();
-        ModificationGroupEntity targetGroup = firstModificationEntity.getGroup();
+        boolean assembleIntoTheGroup = firstModificationEntity.getGroup() != null;
         CompositeModificationEntity targetComposite = null;
-        if (targetGroup == null) {
+        if (!assembleIntoTheGroup) {
             // the first modification is inside a composite
             UUID targetCompositeUuid = modificationRepository.findCompositeIdByContainedModificationId(firstModifUuid);
             targetComposite = compositeModificationRepository.findById(targetCompositeUuid).orElse(null);
@@ -1044,10 +1044,7 @@ public class NetworkModificationRepository {
         // assign modifications
         newCompositeEntity.setModifications(assembledModifications);
         // put the new composite in the target group or composite
-        if (targetGroup != null) {
-            if (groupModifications == null) {
-                groupModifications = targetGroup.getModifications();
-            }
+        if (assembleIntoTheGroup && groupModifications != null) {
             groupModifications.add(targetIndex, newCompositeEntity);
         } else if (targetComposite != null) {
             List<ModificationEntity> modifications = targetComposite.getModifications();
@@ -1057,9 +1054,9 @@ public class NetworkModificationRepository {
             }
         }
 
-        // if the group has been edited :
-        if (groupModifications != null) {
-            targetGroup.setModifications(groupModifications);
+        // if the group has been edited it has to be reordered :
+        if (originGroup != null) {
+            originGroup.setModifications(groupModifications);
         }
 
         return modificationRepository.save(newCompositeEntity);


### PR DESCRIPTION
corrects a reordering problem at the root level when deleting and assembling netmods