### PR TITLE
fix : ignore stashed when reordering groups

### DIFF
--- a/src/main/java/org/gridsuite/modification/server/entities/ModificationGroupEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/ModificationGroupEntity.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -54,7 +55,10 @@ public class ModificationGroupEntity extends AbstractManuallyAssignedIdentifierE
      * @return a mutable ArrayList of the modifications without those stashed
      */
     public List<ModificationEntity> getActiveModifications() {
-        return modifications.stream().filter(m -> !m.getStashed()).collect(Collectors.toCollection(ArrayList::new));
+        return modifications.stream()
+                .filter(Objects::nonNull)
+                .filter(m -> !m.getStashed())
+                .collect(Collectors.toCollection(ArrayList::new));
     }
 
     // adds the modifications to the group and reorders them

--- a/src/main/java/org/gridsuite/modification/server/entities/ModificationGroupEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/ModificationGroupEntity.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * @author Slimane Amar <slimane.amar at rte-france.com>
@@ -49,12 +50,18 @@ public class ModificationGroupEntity extends AbstractManuallyAssignedIdentifierE
         }
     }
 
+    /**
+     * @return a mutable ArrayList of the modifications without those stashed
+     */
+    public List<ModificationEntity> getNotStashedModifications() {
+        return modifications.stream().filter(m -> !m.getStashed()).collect(Collectors.toCollection(ArrayList::new));
+    }
+
     public void setModifications(List<ModificationEntity> modifications) {
         this.modifications = modifications;
         modifications.forEach(m -> m.setGroup(this));
         // the unstashed modifications have to be reordered
-        List<ModificationEntity> unstashedModifications = modifications.stream()
-                .filter(m -> !m.getStashed()).toList();
+        List<ModificationEntity> unstashedModifications = getNotStashedModifications();
         for (int i = 0; i < unstashedModifications.size(); i++) {
             unstashedModifications.get(i).setModificationsOrder(i);
         }

--- a/src/main/java/org/gridsuite/modification/server/entities/ModificationGroupEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/ModificationGroupEntity.java
@@ -53,15 +53,18 @@ public class ModificationGroupEntity extends AbstractManuallyAssignedIdentifierE
     /**
      * @return a mutable ArrayList of the modifications without those stashed
      */
-    public List<ModificationEntity> getNotStashedModifications() {
+    public List<ModificationEntity> getActiveModifications() {
         return modifications.stream().filter(m -> !m.getStashed()).collect(Collectors.toCollection(ArrayList::new));
     }
 
+    // adds the modifications to the group and reorders them
+    // BUT doesn't remove the previous modifications from the group. This has to be done manually because orphanRemoval is set to false.
+    // which means that you may affect a list of the active modifications here, the stashed modifications won't be affected
     public void setModifications(List<ModificationEntity> modifications) {
         this.modifications = modifications;
         modifications.forEach(m -> m.setGroup(this));
         // the unstashed modifications have to be reordered
-        List<ModificationEntity> unstashedModifications = getNotStashedModifications();
+        List<ModificationEntity> unstashedModifications = getActiveModifications();
         for (int i = 0; i < unstashedModifications.size(); i++) {
             unstashedModifications.get(i).setModificationsOrder(i);
         }

--- a/src/main/java/org/gridsuite/modification/server/entities/ModificationGroupEntity.java
+++ b/src/main/java/org/gridsuite/modification/server/entities/ModificationGroupEntity.java
@@ -51,9 +51,12 @@ public class ModificationGroupEntity extends AbstractManuallyAssignedIdentifierE
 
     public void setModifications(List<ModificationEntity> modifications) {
         this.modifications = modifications;
-        for (int i = 0; i < modifications.size(); i++) {
-            modifications.get(i).setModificationsOrder(i);
-            modifications.get(i).setGroup(this);
+        modifications.forEach(m -> m.setGroup(this));
+        // the unstashed modifications have to be reordered
+        List<ModificationEntity> unstashedModifications = modifications.stream()
+                .filter(m -> !m.getStashed()).toList();
+        for (int i = 0; i < unstashedModifications.size(); i++) {
+            unstashedModifications.get(i).setModificationsOrder(i);
         }
     }
 }

--- a/src/main/java/org/gridsuite/modification/server/repositories/NetworkModificationRepository.java
+++ b/src/main/java/org/gridsuite/modification/server/repositories/NetworkModificationRepository.java
@@ -218,7 +218,7 @@ public class NetworkModificationRepository {
     private List<ModificationEntity> moveModificationsNonTransactional(UUID destinationGroupUuid, UUID originGroupUuid, List<UUID> modificationsToMoveUUID, UUID referenceModificationUuid) {
         // read origin group and modifications
         ModificationGroupEntity originModificationGroupEntity = getModificationGroup(originGroupUuid);
-        List<ModificationEntity> originModificationEntities = originModificationGroupEntity.getNotStashedModifications();
+        List<ModificationEntity> originModificationEntities = originModificationGroupEntity.getActiveModifications();
         // To remove null entities when @orderColumn is not a contiguous sequence starting from 0 (to be fixed?)
         // (there are several places in this file where we filter non-null modification entities)
         originModificationEntities.removeIf(Objects::isNull);
@@ -1010,7 +1010,7 @@ public class NetworkModificationRepository {
                 .findFirst()
                 .orElse(null);
         if (originGroup != null) {
-            List<ModificationEntity> originGroupModifications = originGroup.getNotStashedModifications();
+            List<ModificationEntity> originGroupModifications = originGroup.getModifications();
             originGroupModifications.removeIf(mod -> assembledModificationsUuids.contains(mod.getId()));
             originGroup.setModifications(originGroupModifications);
             assembledModifications.forEach(modificationEntity -> modificationEntity.setGroup(null));
@@ -1042,7 +1042,7 @@ public class NetworkModificationRepository {
         newCompositeEntity.setModifications(assembledModifications);
         // put the new composite in the target group or composite
         if (targetGroup != null) {
-            List<ModificationEntity> modifications = targetGroup.getNotStashedModifications();
+            List<ModificationEntity> modifications = targetGroup.getActiveModifications();
             modifications.add(targetIndex, newCompositeEntity);
             targetGroup.setModifications(modifications);
         } else if (targetComposite != null) {
@@ -1093,7 +1093,7 @@ public class NetworkModificationRepository {
         } else {
             // moved from the root level of the network modification table
             ModificationGroupEntity group = getModificationGroup(groupUuid);
-            notMovedMods = group.getNotStashedModifications();
+            notMovedMods = group.getActiveModifications();
             notMovedMods.removeIf(Objects::isNull);
             movedMods = removeModifications(notMovedMods, List.of(modificationUuid));
             if (movedMods.isEmpty()) {

--- a/src/main/java/org/gridsuite/modification/server/repositories/NetworkModificationRepository.java
+++ b/src/main/java/org/gridsuite/modification/server/repositories/NetworkModificationRepository.java
@@ -218,10 +218,7 @@ public class NetworkModificationRepository {
     private List<ModificationEntity> moveModificationsNonTransactional(UUID destinationGroupUuid, UUID originGroupUuid, List<UUID> modificationsToMoveUUID, UUID referenceModificationUuid) {
         // read origin group and modifications
         ModificationGroupEntity originModificationGroupEntity = getModificationGroup(originGroupUuid);
-        List<ModificationEntity> originModificationEntities = originModificationGroupEntity.getModifications()
-            .stream()
-            .filter(modificationEntity -> !modificationEntity.getStashed())
-            .collect(Collectors.toList());
+        List<ModificationEntity> originModificationEntities = originModificationGroupEntity.getNotStashedModifications();
         // To remove null entities when @orderColumn is not a contiguous sequence starting from 0 (to be fixed?)
         // (there are several places in this file where we filter non-null modification entities)
         originModificationEntities.removeIf(Objects::isNull);
@@ -1013,7 +1010,7 @@ public class NetworkModificationRepository {
                 .findFirst()
                 .orElse(null);
         if (originGroup != null) {
-            List<ModificationEntity> originGroupModifications = originGroup.getModifications();
+            List<ModificationEntity> originGroupModifications = originGroup.getNotStashedModifications();
             originGroupModifications.removeIf(mod -> assembledModificationsUuids.contains(mod.getId()));
             originGroup.setModifications(originGroupModifications);
             assembledModifications.forEach(modificationEntity -> modificationEntity.setGroup(null));
@@ -1045,7 +1042,7 @@ public class NetworkModificationRepository {
         newCompositeEntity.setModifications(assembledModifications);
         // put the new composite in the target group or composite
         if (targetGroup != null) {
-            List<ModificationEntity> modifications = targetGroup.getModifications();
+            List<ModificationEntity> modifications = targetGroup.getNotStashedModifications();
             modifications.add(targetIndex, newCompositeEntity);
             targetGroup.setModifications(modifications);
         } else if (targetComposite != null) {
@@ -1096,10 +1093,7 @@ public class NetworkModificationRepository {
         } else {
             // moved from the root level of the network modification table
             ModificationGroupEntity group = getModificationGroup(groupUuid);
-            notMovedMods = group.getModifications()
-                    .stream()
-                    .filter(m -> !m.getStashed())
-                    .collect(Collectors.toList());
+            notMovedMods = group.getNotStashedModifications();
             notMovedMods.removeIf(Objects::isNull);
             movedMods = removeModifications(notMovedMods, List.of(modificationUuid));
             if (movedMods.isEmpty()) {


### PR DESCRIPTION
ignore stashed when reordering groups

Plus small refacto in order to use the same `getNotStashedModifications` new function several time in the code.


