### PR TITLE
include composite content in uuids mapping

### DIFF
--- a/src/main/java/org/gridsuite/modification/server/NetworkModificationController.java
+++ b/src/main/java/org/gridsuite/modification/server/NetworkModificationController.java
@@ -88,6 +88,9 @@ public class NetworkModificationController {
         return ResponseEntity.ok().body(networkModificationService.getNetworkModificationsCount(groupUuid, stashed));
     }
 
+    /**
+     * @return a mapping of the duplicated group's modifications' UUIDs to the new group's modifications' UUIDs, including those contained inside composites
+     */
     @PostMapping(value = "/groups")
     @Operation(summary = "Create a modification group based on another group")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "The group and its modifications have been duplicated")})

--- a/src/main/java/org/gridsuite/modification/server/service/NetworkModificationService.java
+++ b/src/main/java/org/gridsuite/modification/server/service/NetworkModificationService.java
@@ -86,7 +86,7 @@ public class NetworkModificationService {
     static final String CREATED_EQUIPMENT_IDS = "createdEquipmentIds.fullascii";
     static final String MODIFIED_EQUIPMENT_IDS = "modifiedEquipmentIds.fullascii";
     static final String DELETED_EQUIPMENT_IDS = "deletedEquipmentIds.fullascii";
-    static final String DIFFERENT_SIZES_ERROR_MESSAGE =
+    static final String MODIFICATION_LIST_SIZE_MISMATCH_ERROR =
             "Error while mapping two modifications list with each other : both lists have different sizes";
     private final ModificationRepository modificationRepository;
     private static final int PAGE_MAX_SIZE = 500;
@@ -461,23 +461,28 @@ public class NetworkModificationService {
         }
     }
 
+    private List<ModificationInfos> getNestedModifications(ModificationInfos modificationInfos) {
+        return modificationInfos instanceof CompositeModificationInfos composite && composite.getModificationsInfos() != null
+                ? composite.getModificationsInfos()
+                : List.of();
+    }
+
     /**
      * recursively map the uuids from two lists of modifications, including those inside the composite modifications
      */
-    static void mapUuidsFromTwoModificationsLists(
+    void mapUuidsFromTwoModificationsLists(
             List<ModificationInfos> modificationsList1,
             List<ModificationInfos> modificationsList2,
             Map<UUID, UUID> modificationsMapping) {
         if (modificationsList1.size() != modificationsList2.size()) {
-            throw new IllegalArgumentException(DIFFERENT_SIZES_ERROR_MESSAGE);
+            throw new IllegalArgumentException(MODIFICATION_LIST_SIZE_MISMATCH_ERROR);
         }
         for (int i = 0; i < modificationsList1.size(); i++) {
             modificationsMapping.put(modificationsList1.get(i).getUuid(), modificationsList2.get(i).getUuid());
-            if (modificationsList1.get(i).getType() == ModificationType.COMPOSITE_MODIFICATION) {
-                CompositeModificationInfos compositeToDuplicateInfos = (CompositeModificationInfos) modificationsList1.get(i);
-                CompositeModificationInfos newComposite = (CompositeModificationInfos) modificationsList2.get(i);
-                mapUuidsFromTwoModificationsLists(compositeToDuplicateInfos.getModificationsInfos(), newComposite.getModificationsInfos(), modificationsMapping);
-            }
+            mapUuidsFromTwoModificationsLists(
+                    getNestedModifications(modificationsList1.get(i)),
+                    getNestedModifications(modificationsList2.get(i)),
+                    modificationsMapping);
         }
     }
 

--- a/src/main/java/org/gridsuite/modification/server/service/NetworkModificationService.java
+++ b/src/main/java/org/gridsuite/modification/server/service/NetworkModificationService.java
@@ -86,6 +86,8 @@ public class NetworkModificationService {
     static final String CREATED_EQUIPMENT_IDS = "createdEquipmentIds.fullascii";
     static final String MODIFIED_EQUIPMENT_IDS = "modifiedEquipmentIds.fullascii";
     static final String DELETED_EQUIPMENT_IDS = "deletedEquipmentIds.fullascii";
+    static final String DIFFERENT_SIZES_ERROR_MESSAGE =
+            "Error while mapping two modifications list with each other : both lists have different sizes";
     private final ModificationRepository modificationRepository;
     private static final int PAGE_MAX_SIZE = 500;
 
@@ -462,12 +464,12 @@ public class NetworkModificationService {
     /**
      * recursively map the uuids from two lists of modifications, including those inside the composite modifications
      */
-    private static void mapUuidsFromTwoModificationsLists(
+    static void mapUuidsFromTwoModificationsLists(
             List<ModificationInfos> modificationsList1,
             List<ModificationInfos> modificationsList2,
             Map<UUID, UUID> modificationsMapping) {
         if (modificationsList1.size() != modificationsList2.size()) {
-            throw new IllegalArgumentException("Error while mapping two modifications list with each other : both lists have different sizes");
+            throw new IllegalArgumentException(DIFFERENT_SIZES_ERROR_MESSAGE);
         }
         for (int i = 0; i < modificationsList1.size(); i++) {
             modificationsMapping.put(modificationsList1.get(i).getUuid(), modificationsList2.get(i).getUuid());

--- a/src/main/java/org/gridsuite/modification/server/service/NetworkModificationService.java
+++ b/src/main/java/org/gridsuite/modification/server/service/NetworkModificationService.java
@@ -439,15 +439,16 @@ public class NetworkModificationService {
                 groupUuid, sourceCompositeUuid, targetCompositeUuid, modificationUuid, beforeUuid);
     }
 
+    /**
+     * @return a mapping between the uuids of the duplicated modifications and the uuid of the new modifications
+     */
     public Map<UUID, UUID> duplicateGroup(@NonNull UUID sourceGroupUuid, @NonNull UUID targetGroupUuid) {
         try {
             List<ModificationInfos> modificationToDuplicateInfos = networkModificationRepository.getUnstashedModificationsInfos(sourceGroupUuid);
             List<ModificationInfos> newModifications = networkModificationRepository.saveModificationInfos(targetGroupUuid, modificationToDuplicateInfos);
 
             Map<UUID, UUID> duplicateModificationMapping = new HashMap<>();
-            for (int i = 0; i < modificationToDuplicateInfos.size(); i++) {
-                duplicateModificationMapping.put(modificationToDuplicateInfos.get(i).getUuid(), newModifications.get(i).getUuid());
-            }
+            mapUuidsFromTwoModificationsLists(modificationToDuplicateInfos, newModifications, duplicateModificationMapping);
 
             return duplicateModificationMapping;
         } catch (NetworkModificationException e) {
@@ -455,6 +456,26 @@ public class NetworkModificationService {
                 return Map.of();
             }
             throw e;
+        }
+    }
+
+    /**
+     * resursively map the uuids from two lists of modifications, including those inside the composite modifications
+     */
+    private static void mapUuidsFromTwoModificationsLists(
+            List<ModificationInfos> modificationList1,
+            List<ModificationInfos> modificationsList2,
+            Map<UUID, UUID> modificationsMapping) throws RuntimeException {
+        if (modificationList1.size() != modificationsList2.size()) {
+            throw new RuntimeException("Error while mapping two modifications list with each other");
+        }
+        for (int i = 0; i < modificationList1.size(); i++) {
+            modificationsMapping.put(modificationList1.get(i).getUuid(), modificationsList2.get(i).getUuid());
+            if (modificationList1.get(i).getType() == ModificationType.COMPOSITE_MODIFICATION) {
+                CompositeModificationInfos compositeToDuplicateInfos = (CompositeModificationInfos) modificationList1.get(i);
+                CompositeModificationInfos newComposite = (CompositeModificationInfos) modificationsList2.get(i);
+                mapUuidsFromTwoModificationsLists(compositeToDuplicateInfos.getModificationsInfos(), newComposite.getModificationsInfos(), modificationsMapping);
+            }
         }
     }
 

--- a/src/main/java/org/gridsuite/modification/server/service/NetworkModificationService.java
+++ b/src/main/java/org/gridsuite/modification/server/service/NetworkModificationService.java
@@ -460,19 +460,19 @@ public class NetworkModificationService {
     }
 
     /**
-     * resursively map the uuids from two lists of modifications, including those inside the composite modifications
+     * recursively map the uuids from two lists of modifications, including those inside the composite modifications
      */
     private static void mapUuidsFromTwoModificationsLists(
-            List<ModificationInfos> modificationList1,
+            List<ModificationInfos> modificationsList1,
             List<ModificationInfos> modificationsList2,
-            Map<UUID, UUID> modificationsMapping) throws RuntimeException {
-        if (modificationList1.size() != modificationsList2.size()) {
-            throw new RuntimeException("Error while mapping two modifications list with each other");
+            Map<UUID, UUID> modificationsMapping) {
+        if (modificationsList1.size() != modificationsList2.size()) {
+            throw new IllegalArgumentException("Error while mapping two modifications list with each other : both lists have different sizes");
         }
-        for (int i = 0; i < modificationList1.size(); i++) {
-            modificationsMapping.put(modificationList1.get(i).getUuid(), modificationsList2.get(i).getUuid());
-            if (modificationList1.get(i).getType() == ModificationType.COMPOSITE_MODIFICATION) {
-                CompositeModificationInfos compositeToDuplicateInfos = (CompositeModificationInfos) modificationList1.get(i);
+        for (int i = 0; i < modificationsList1.size(); i++) {
+            modificationsMapping.put(modificationsList1.get(i).getUuid(), modificationsList2.get(i).getUuid());
+            if (modificationsList1.get(i).getType() == ModificationType.COMPOSITE_MODIFICATION) {
+                CompositeModificationInfos compositeToDuplicateInfos = (CompositeModificationInfos) modificationsList1.get(i);
                 CompositeModificationInfos newComposite = (CompositeModificationInfos) modificationsList2.get(i);
                 mapUuidsFromTwoModificationsLists(compositeToDuplicateInfos.getModificationsInfos(), newComposite.getModificationsInfos(), modificationsMapping);
             }

--- a/src/test/java/org/gridsuite/modification/server/service/NetworkModificationServiceTest.java
+++ b/src/test/java/org/gridsuite/modification/server/service/NetworkModificationServiceTest.java
@@ -1,0 +1,148 @@
+package org.gridsuite.modification.server.service;
+
+import org.gridsuite.modification.dto.CompositeModificationInfos;
+import org.gridsuite.modification.dto.LoadModificationInfos;
+import org.gridsuite.modification.dto.ModificationInfos;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.gridsuite.modification.server.service.NetworkModificationService.DIFFERENT_SIZES_ERROR_MESSAGE;
+import static org.gridsuite.modification.server.service.NetworkModificationService.mapUuidsFromTwoModificationsLists;
+import static org.junit.jupiter.api.Assertions.*;
+
+class NetworkModificationServiceTest {
+    @Test
+    void shouldMapUuidsFromTwoModificationsLists() {
+        UUID sourceModificationUuid1 = UUID.randomUUID();
+        UUID sourceModificationUuid2 = UUID.randomUUID();
+        UUID duplicatedModificationUuid1 = UUID.randomUUID();
+        UUID duplicatedModificationUuid2 = UUID.randomUUID();
+
+        List<ModificationInfos> sourceModifications = List.of(
+                dummyModification(sourceModificationUuid1),
+                dummyModification(sourceModificationUuid2)
+        );
+        List<ModificationInfos> duplicatedModifications = List.of(
+                dummyModification(duplicatedModificationUuid1),
+                dummyModification(duplicatedModificationUuid2)
+        );
+
+        Map<UUID, UUID> modificationsMapping = new HashMap<>();
+
+        mapUuidsFromTwoModificationsLists(sourceModifications, duplicatedModifications, modificationsMapping);
+
+        assertEquals(2, modificationsMapping.size());
+        assertEquals(duplicatedModificationUuid1, modificationsMapping.get(sourceModificationUuid1));
+        assertEquals(duplicatedModificationUuid2, modificationsMapping.get(sourceModificationUuid2));
+    }
+
+    @Test
+    void shouldRecursivelyMapUuidsFromCompositeModifications() {
+        UUID sourceCompositeUuid = UUID.randomUUID();
+        UUID sourceChildUuid1 = UUID.randomUUID();
+        UUID sourceChildUuid2 = UUID.randomUUID();
+
+        UUID duplicatedCompositeUuid = UUID.randomUUID();
+        UUID duplicatedChildUuid1 = UUID.randomUUID();
+        UUID duplicatedChildUuid2 = UUID.randomUUID();
+
+        CompositeModificationInfos sourceComposite = compositeModification(
+                sourceCompositeUuid,
+                List.of(
+                        dummyModification(sourceChildUuid1),
+                        dummyModification(sourceChildUuid2)
+                )
+        );
+
+        CompositeModificationInfos duplicatedComposite = compositeModification(
+                duplicatedCompositeUuid,
+                List.of(
+                        dummyModification(duplicatedChildUuid1),
+                        dummyModification(duplicatedChildUuid2)
+                )
+        );
+
+        Map<UUID, UUID> modificationsMapping = new HashMap<>();
+
+        mapUuidsFromTwoModificationsLists(
+                List.of(sourceComposite),
+                List.of(duplicatedComposite),
+                modificationsMapping
+        );
+
+        assertEquals(3, modificationsMapping.size());
+        assertEquals(duplicatedCompositeUuid, modificationsMapping.get(sourceCompositeUuid));
+        assertEquals(duplicatedChildUuid1, modificationsMapping.get(sourceChildUuid1));
+        assertEquals(duplicatedChildUuid2, modificationsMapping.get(sourceChildUuid2));
+    }
+
+    @Test
+    void shouldThrowIllegalArgumentExceptionWhenRootListsHaveDifferentSizes() {
+        List<ModificationInfos> sourceModifications = List.of(
+                dummyModification(UUID.randomUUID()),
+                dummyModification(UUID.randomUUID())
+        );
+        List<ModificationInfos> duplicatedModifications = List.of(
+                dummyModification(UUID.randomUUID())
+        );
+
+        Map<UUID, UUID> modificationsMapping = new HashMap<>();
+        IllegalArgumentException exception = assertThrowsExactly(
+                IllegalArgumentException.class,
+                () -> mapUuidsFromTwoModificationsLists(
+                        sourceModifications,
+                        duplicatedModifications,
+                        modificationsMapping
+                )
+        );
+        assertEquals(DIFFERENT_SIZES_ERROR_MESSAGE, exception.getMessage());
+    }
+
+    @Test
+    void shouldThrowIllegalArgumentExceptionWhenCompositeChildrenListsHaveDifferentSizes() {
+        UUID sourceCompositeUuid = UUID.randomUUID();
+        UUID duplicatedCompositeUuid = UUID.randomUUID();
+
+        CompositeModificationInfos sourceComposite = compositeModification(
+                sourceCompositeUuid,
+                List.of(
+                        dummyModification(UUID.randomUUID()),
+                        dummyModification(UUID.randomUUID())
+                )
+        );
+
+        CompositeModificationInfos duplicatedComposite = compositeModification(
+                duplicatedCompositeUuid,
+                List.of(dummyModification(UUID.randomUUID()))
+        );
+
+        Map<UUID, UUID> modificationsMapping = new HashMap<>();
+        IllegalArgumentException exception = assertThrowsExactly(
+                IllegalArgumentException.class,
+                () -> mapUuidsFromTwoModificationsLists(
+                        List.of(sourceComposite),
+                        List.of(duplicatedComposite),
+                        modificationsMapping
+                )
+        );
+        assertEquals(DIFFERENT_SIZES_ERROR_MESSAGE, exception.getMessage());
+    }
+
+    private static LoadModificationInfos dummyModification(UUID uuid) {
+        return LoadModificationInfos.builder()
+                .equipmentId("dummyEquipmentId")
+                .uuid(uuid)
+                .build();
+    }
+
+    private static CompositeModificationInfos compositeModification(UUID uuid, List<ModificationInfos> children) {
+        return CompositeModificationInfos.builder()
+                .uuid(uuid)
+                .modificationsInfos(children)
+                .build();
+    }
+}

--- a/src/test/java/org/gridsuite/modification/server/service/NetworkModificationServiceTest.java
+++ b/src/test/java/org/gridsuite/modification/server/service/NetworkModificationServiceTest.java
@@ -1,20 +1,35 @@
+/**
+ * Copyright (c) 2026, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package org.gridsuite.modification.server.service;
 
 import org.gridsuite.modification.dto.CompositeModificationInfos;
 import org.gridsuite.modification.dto.LoadModificationInfos;
 import org.gridsuite.modification.dto.ModificationInfos;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import static org.gridsuite.modification.server.service.NetworkModificationService.DIFFERENT_SIZES_ERROR_MESSAGE;
-import static org.gridsuite.modification.server.service.NetworkModificationService.mapUuidsFromTwoModificationsLists;
+import static org.gridsuite.modification.server.service.NetworkModificationService.MODIFICATION_LIST_SIZE_MISMATCH_ERROR;
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * @author Mathieu Deharbe <mathieu.deharbe at rte-france.com>
+ */
+@SpringBootTest
 class NetworkModificationServiceTest {
+
+    @Autowired
+    private NetworkModificationService networkModificationService;
+
     @Test
     void shouldMapUuidsFromTwoModificationsLists() {
         UUID sourceModificationUuid1 = UUID.randomUUID();
@@ -33,7 +48,7 @@ class NetworkModificationServiceTest {
 
         Map<UUID, UUID> modificationsMapping = new HashMap<>();
 
-        mapUuidsFromTwoModificationsLists(sourceModifications, duplicatedModifications, modificationsMapping);
+        networkModificationService.mapUuidsFromTwoModificationsLists(sourceModifications, duplicatedModifications, modificationsMapping);
 
         assertEquals(2, modificationsMapping.size());
         assertEquals(duplicatedModificationUuid1, modificationsMapping.get(sourceModificationUuid1));
@@ -68,7 +83,7 @@ class NetworkModificationServiceTest {
 
         Map<UUID, UUID> modificationsMapping = new HashMap<>();
 
-        mapUuidsFromTwoModificationsLists(
+        networkModificationService.mapUuidsFromTwoModificationsLists(
                 List.of(sourceComposite),
                 List.of(duplicatedComposite),
                 modificationsMapping
@@ -93,13 +108,13 @@ class NetworkModificationServiceTest {
         Map<UUID, UUID> modificationsMapping = new HashMap<>();
         IllegalArgumentException exception = assertThrowsExactly(
                 IllegalArgumentException.class,
-                () -> mapUuidsFromTwoModificationsLists(
+                () -> networkModificationService.mapUuidsFromTwoModificationsLists(
                         sourceModifications,
                         duplicatedModifications,
                         modificationsMapping
                 )
         );
-        assertEquals(DIFFERENT_SIZES_ERROR_MESSAGE, exception.getMessage());
+        assertEquals(MODIFICATION_LIST_SIZE_MISMATCH_ERROR, exception.getMessage());
     }
 
     @Test
@@ -123,13 +138,13 @@ class NetworkModificationServiceTest {
         Map<UUID, UUID> modificationsMapping = new HashMap<>();
         IllegalArgumentException exception = assertThrowsExactly(
                 IllegalArgumentException.class,
-                () -> mapUuidsFromTwoModificationsLists(
+                () -> networkModificationService.mapUuidsFromTwoModificationsLists(
                         List.of(sourceComposite),
                         List.of(duplicatedComposite),
                         modificationsMapping
                 )
         );
-        assertEquals(DIFFERENT_SIZES_ERROR_MESSAGE, exception.getMessage());
+        assertEquals(MODIFICATION_LIST_SIZE_MISMATCH_ERROR, exception.getMessage());
     }
 
     private static LoadModificationInfos dummyModification(UUID uuid) {


### PR DESCRIPTION
Those uuids are used in order to replicate the applicability from the duplicated modifications to the newly created ones. So this corrects a root network applicability bug  when copying a study, node, or list of modifications which contains at least a composite.


