### PR TITLE
Add an endpoint sharing a composite modification of a group

### DIFF
--- a/src/main/java/org/gridsuite/modification/server/CompositeController.java
+++ b/src/main/java/org/gridsuite/modification/server/CompositeController.java
@@ -84,12 +84,13 @@ public class CompositeController {
 
     @PostMapping(value = "/{uuid}/share")
     @Operation(summary = "Extract a composite modification from its group, replacing it by a reference to it")
-    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "The composite modification has been extracted, its uuid is returned")})
-    public ResponseEntity<UUID> extractCompositeModificationToShare(
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "The composite modification has been extracted")})
+    public ResponseEntity<Void> extractCompositeModificationToShare(
             @PathVariable("uuid") UUID compositeModificationUuid,
             @Parameter(description = "Group owning the composite modification", required = true) @RequestParam("groupUuid") UUID groupUuid,
             @Parameter(description = "New name of the shared composite modification") @RequestParam(value = "name", required = false) String name) {
-        return ResponseEntity.ok().body(networkModificationService.extractCompositeModificationToShare(groupUuid, compositeModificationUuid, name));
+        networkModificationService.extractCompositeModificationToShare(groupUuid, compositeModificationUuid, name);
+        return ResponseEntity.ok().build();
     }
 
     @GetMapping(value = "/network-modifications", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/org/gridsuite/modification/server/CompositeController.java
+++ b/src/main/java/org/gridsuite/modification/server/CompositeController.java
@@ -82,6 +82,16 @@ public class CompositeController {
         return ResponseEntity.ok().body(networkModificationService.createNetworkCompositeModification(modificationUuids, name));
     }
 
+    @PostMapping(value = "/{uuid}/share")
+    @Operation(summary = "Extract a composite modification from its group, replacing it by a reference to it")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "The composite modification has been extracted, its uuid is returned")})
+    public ResponseEntity<UUID> extractCompositeModificationToShare(
+            @PathVariable("uuid") UUID compositeModificationUuid,
+            @Parameter(description = "Group owning the composite modification", required = true) @RequestParam("groupUuid") UUID groupUuid,
+            @Parameter(description = "New name of the shared composite modification") @RequestParam(value = "name", required = false) String name) {
+        return ResponseEntity.ok().body(networkModificationService.extractCompositeModificationToShare(groupUuid, compositeModificationUuid, name));
+    }
+
     @GetMapping(value = "/network-modifications", produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(summary = "Get the list of all the network modifications inside a list of composite modifications")
     @ApiResponse(responseCode = "200", description = "Map of modifications inside the composite modifications for each composite")

--- a/src/main/java/org/gridsuite/modification/server/error/ModificationBusinessErrorCode.java
+++ b/src/main/java/org/gridsuite/modification/server/error/ModificationBusinessErrorCode.java
@@ -16,6 +16,7 @@ public enum ModificationBusinessErrorCode implements BusinessErrorCode {
     MODIFICATION_CONTAINER_TYPE_NOT_FOUND("modification.container.type.notFound", "Modification container type of %s is not found"),
     MODIFICATION_CONTAINER_BAD_TYPE("modification.container.badType", "Modification container type of %s is invalid : actual type %s -> expected type %s"),
     MODIFICATION_NOT_FOUND("modification.notFound", "Modification (%s) not found"),
+    MODIFICATION_BAD_TYPE("modification.badType", "Modification type of %s is invalid : actual type %s -> expected type %s"),
     MODIFICATIONS_NOT_FOUND("modifications.notFound"),
     MODIFICATION_INFOS_ERROR("modification.infos.error", "Modification infos error : %s"),
     MODIFICATION_WITH_GROUP_DELETION_FORBIDDEN("modification.with_group.deletion.forbidden", "Deletion forbidden : modification %s is owned by group %s"),

--- a/src/main/java/org/gridsuite/modification/server/error/NetworkModificationExceptionHandler.java
+++ b/src/main/java/org/gridsuite/modification/server/error/NetworkModificationExceptionHandler.java
@@ -41,7 +41,8 @@ public class NetworkModificationExceptionHandler extends AbstractBusinessExcepti
                  NETWORK_NOT_FOUND,
                  VARIANT_NOT_FOUND
                  -> HttpStatus.NOT_FOUND;
-            case MODIFICATION_CONTAINER_BAD_TYPE,
+            case MODIFICATION_BAD_TYPE,
+                 MODIFICATION_CONTAINER_BAD_TYPE,
                  MODIFICATION_INFOS_ERROR,
                  MODIFICATION_WITH_GROUP_DELETION_FORBIDDEN,
                  MODIFICATION_DELETION_ARGUMENT_ERROR,

--- a/src/main/java/org/gridsuite/modification/server/repositories/NetworkModificationRepository.java
+++ b/src/main/java/org/gridsuite/modification/server/repositories/NetworkModificationRepository.java
@@ -1043,6 +1043,51 @@ public class NetworkModificationRepository {
         return newEntities.stream().map(ModificationEntity::toModificationInfos).toList();
     }
 
+    /**
+     * Takes a composite modification out of its group so that it can be stored as an element in the directory server,
+     * and puts a reference to it at the very same place in the group.
+     * @param groupUuid group owning the composite modification
+     * @param modificationUuid uuid of the composite modification to share
+     * @param name name given to the shared composite modification, null to keep the current one
+     * @return the uuid of the extracted composite modification, now standalone
+     */
+    @Transactional
+    public UUID extractCompositeModificationToShare(@NonNull UUID groupUuid, @NonNull UUID modificationUuid, String name) {
+        ModificationGroupEntity groupEntity = getModificationGroup(groupUuid);
+        ModificationEntity modificationEntity = getModificationEntity(modificationUuid);
+        if (!(modificationEntity instanceof CompositeModificationEntity compositeEntity)) {
+            String expectedType = ModificationType.COMPOSITE_MODIFICATION.name();
+            throw new NetworkModificationServerException(MODIFICATION_BAD_TYPE,
+                String.format(MODIFICATION_BAD_TYPE.messageTemplate(), modificationUuid, modificationEntity.getType(), expectedType),
+                Map.of("modificationId", modificationUuid.toString(), "modificationType", modificationEntity.getType(), "expectedModificationType", expectedType));
+        }
+        if (!groupUuid.equals(modificationEntity.getContainerUuid())) {
+            throw new NetworkModificationServerException(MODIFICATION_NOT_FOUND,
+                String.format("Modification %s is not owned by group %s", modificationUuid, groupUuid),
+                Map.of("modificationId", modificationUuid + " (group = " + groupUuid + ")"));
+        }
+
+        ModificationReferenceInfos referenceInfos = ModificationReferenceInfos.builder()
+            .referenceId(modificationUuid)
+            .referenceType(ModificationReferenceInfos.Type.BASIC)
+            .referenceInfos(loadCompositeModificationMetadata(compositeEntity, null))
+            .build();
+        ModificationEntity referenceEntity = ModificationEntity.fromDTO(referenceInfos);
+
+        // the reference takes the place - and the order - of the shared composite modification
+        groupEntity.addModification(referenceEntity, compositeEntity.getModificationsOrder());
+        groupEntity.removeModifications(List.of(modificationUuid));
+        compositeEntity.setContainer(null);
+        compositeEntity.setModificationsOrder(0);
+        if (name != null) {
+            compositeModificationRepository.renameCompositeModification(compositeEntity, name);
+        }
+
+        modificationRepository.save(referenceEntity);
+        modificationRepository.save(compositeEntity);
+        return modificationUuid;
+    }
+
     private AbstractModificationContainerEntity getContainer(ModificationContainerInfos containerInfos) {
         AbstractModificationContainerEntity containerEntity = modificationContainerRepository.findById(containerInfos.id()).orElseGet(() -> {
             if (ModificationContainerType.GROUP.equals(containerInfos.type())) {

--- a/src/main/java/org/gridsuite/modification/server/repositories/NetworkModificationRepository.java
+++ b/src/main/java/org/gridsuite/modification/server/repositories/NetworkModificationRepository.java
@@ -75,6 +75,7 @@ public class NetworkModificationRepository {
     private final ModificationApplicationInfosService modificationApplicationInfosService;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(NetworkModificationRepository.class);
+    private static final String MODIFICATION_ID = "modificationId";
 
     public NetworkModificationRepository(ModificationGroupRepository modificationGroupRepository,
                                          ModificationRepository modificationRepository,
@@ -123,7 +124,7 @@ public class NetworkModificationRepository {
     }
 
     private NetworkModificationServerException getModificationNotFoundException(String modificationId) {
-        return new NetworkModificationServerException(MODIFICATION_NOT_FOUND, String.format(MODIFICATION_NOT_FOUND.messageTemplate(), modificationId), Map.of("modificationId", modificationId));
+        return new NetworkModificationServerException(MODIFICATION_NOT_FOUND, String.format(MODIFICATION_NOT_FOUND.messageTemplate(), modificationId), Map.of(MODIFICATION_ID, modificationId));
     }
 
     @Transactional // To have all the delete in the same transaction (atomic)
@@ -648,7 +649,7 @@ public class NetworkModificationRepository {
             if (optionalModificationWithGroup.isPresent()) {
                 throw new NetworkModificationServerException(MODIFICATION_WITH_GROUP_DELETION_FORBIDDEN,
                     String.format(MODIFICATION_WITH_GROUP_DELETION_FORBIDDEN.messageTemplate(), optionalModificationWithGroup.get().getId(), optionalModificationWithGroup.get().getContainerUuid()),
-                    Map.of("modificationId", optionalModificationWithGroup.get().getId(), "groupId", optionalModificationWithGroup.get().getContainerUuid()));
+                    Map.of(MODIFICATION_ID, optionalModificationWithGroup.get().getId(), "groupId", optionalModificationWithGroup.get().getContainerUuid()));
             }
         } else {
             throw new NetworkModificationServerException(MODIFICATION_DELETION_ARGUMENT_ERROR, MODIFICATION_DELETION_ARGUMENT_ERROR.messageTemplate());
@@ -1059,12 +1060,12 @@ public class NetworkModificationRepository {
             String expectedType = ModificationType.COMPOSITE_MODIFICATION.name();
             throw new NetworkModificationServerException(MODIFICATION_BAD_TYPE,
                 String.format(MODIFICATION_BAD_TYPE.messageTemplate(), modificationUuid, modificationEntity.getType(), expectedType),
-                Map.of("modificationId", modificationUuid.toString(), "modificationType", modificationEntity.getType(), "expectedModificationType", expectedType));
+                Map.of(MODIFICATION_ID, modificationUuid.toString(), "modificationType", modificationEntity.getType(), "expectedModificationType", expectedType));
         }
         if (!groupUuid.equals(modificationEntity.getContainerUuid())) {
             throw new NetworkModificationServerException(MODIFICATION_NOT_FOUND,
                 String.format("Modification %s is not owned by group %s", modificationUuid, groupUuid),
-                Map.of("modificationId", modificationUuid + " (group = " + groupUuid + ")"));
+                Map.of(MODIFICATION_ID, modificationUuid + " (group = " + groupUuid + ")"));
         }
 
         ModificationReferenceInfos referenceInfos = ModificationReferenceInfos.builder()

--- a/src/main/java/org/gridsuite/modification/server/repositories/NetworkModificationRepository.java
+++ b/src/main/java/org/gridsuite/modification/server/repositories/NetworkModificationRepository.java
@@ -1065,7 +1065,7 @@ public class NetworkModificationRepository {
         if (!groupUuid.equals(modificationEntity.getContainerUuid())) {
             throw new NetworkModificationServerException(MODIFICATION_NOT_FOUND,
                 String.format("Modification %s is not owned by group %s", modificationUuid, groupUuid),
-                Map.of(MODIFICATION_ID, modificationUuid + " (group = " + groupUuid + ")"));
+                Map.of(MODIFICATION_ID, modificationUuid, "groupId", groupUuid));
         }
 
         ModificationReferenceInfos referenceInfos = ModificationReferenceInfos.builder()

--- a/src/main/java/org/gridsuite/modification/server/repositories/NetworkModificationRepository.java
+++ b/src/main/java/org/gridsuite/modification/server/repositories/NetworkModificationRepository.java
@@ -1046,14 +1046,14 @@ public class NetworkModificationRepository {
 
     /**
      * Takes a composite modification out of its group so that it can be stored as an element in the directory server,
-     * and puts a reference to it at the very same place in the group.
+     * and puts a reference to it at the very same place in the group. The composite modification keeps the same uuid,
+     * only its container changes.
      * @param groupUuid group owning the composite modification
      * @param modificationUuid uuid of the composite modification to share
      * @param name name given to the shared composite modification, null to keep the current one
-     * @return the uuid of the extracted composite modification, now standalone
      */
     @Transactional
-    public UUID extractCompositeModificationToShare(@NonNull UUID groupUuid, @NonNull UUID modificationUuid, String name) {
+    public void extractCompositeModificationToShare(@NonNull UUID groupUuid, @NonNull UUID modificationUuid, String name) {
         ModificationGroupEntity groupEntity = getModificationGroup(groupUuid);
         ModificationEntity modificationEntity = getModificationEntity(modificationUuid);
         if (!(modificationEntity instanceof CompositeModificationEntity compositeEntity)) {
@@ -1086,7 +1086,6 @@ public class NetworkModificationRepository {
 
         modificationRepository.save(referenceEntity);
         modificationRepository.save(compositeEntity);
-        return modificationUuid;
     }
 
     private AbstractModificationContainerEntity getContainer(ModificationContainerInfos containerInfos) {

--- a/src/main/java/org/gridsuite/modification/server/service/NetworkModificationService.java
+++ b/src/main/java/org/gridsuite/modification/server/service/NetworkModificationService.java
@@ -553,6 +553,11 @@ public class NetworkModificationService {
         return networkModificationRepository.createNetworkCompositeModification(modificationUuids, name);
     }
 
+    @Transactional
+    public UUID extractCompositeModificationToShare(@NonNull UUID groupUuid, @NonNull UUID modificationUuid, String name) {
+        return networkModificationRepository.extractCompositeModificationToShare(groupUuid, modificationUuid, name);
+    }
+
     public Map<UUID, UUID> duplicateCompositeModifications(List<UUID> sourceModificationUuids) {
         return networkModificationRepository.duplicateCompositeModifications(sourceModificationUuids);
     }

--- a/src/main/java/org/gridsuite/modification/server/service/NetworkModificationService.java
+++ b/src/main/java/org/gridsuite/modification/server/service/NetworkModificationService.java
@@ -554,8 +554,8 @@ public class NetworkModificationService {
     }
 
     @Transactional
-    public UUID extractCompositeModificationToShare(@NonNull UUID groupUuid, @NonNull UUID modificationUuid, String name) {
-        return networkModificationRepository.extractCompositeModificationToShare(groupUuid, modificationUuid, name);
+    public void extractCompositeModificationToShare(@NonNull UUID groupUuid, @NonNull UUID modificationUuid, String name) {
+        networkModificationRepository.extractCompositeModificationToShare(groupUuid, modificationUuid, name);
     }
 
     public Map<UUID, UUID> duplicateCompositeModifications(List<UUID> sourceModificationUuids) {

--- a/src/test/java/org/gridsuite/modification/server/CompositeControllerTest.java
+++ b/src/test/java/org/gridsuite/modification/server/CompositeControllerTest.java
@@ -275,6 +275,58 @@ class CompositeControllerTest {
         checkCompositeModificationContent(referencedComposite.getModificationsInfos());
     }
 
+    @Test
+    void testExtractCompositeModificationToShare() throws Exception {
+        int modificationsNumber = 2;
+        List<ModificationInfos> modificationList = createSomeSwitchModifications(TEST_GROUP_ID, modificationsNumber);
+
+        MvcResult mvcResult = mockMvc.perform(post(URI_COMPOSITE_NETWORK_MODIF_BASE).queryParam("name", "composite name")
+                        .content(mapper.writeValueAsString(modificationList.stream().map(ModificationInfos::getUuid).toList()))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+        UUID standaloneCompositeUuid = mapper.readValue(mvcResult.getResponse().getContentAsString(), new TypeReference<>() { });
+
+        // the composite modification to share is inserted into the group, as a composite of its own
+        runRequestAsync(
+                mockMvc,
+                put(URI_COMPOSITE_NETWORK_MODIF_BASE + "/groups/" + TEST_GROUP_ID + "?action=INSERT")
+                        .content(getJsonBodyModificationCompositeToBeInserted(
+                                List.of(new CompositeInfos(standaloneCompositeUuid, "composite in the study", false, "description"))))
+                        .contentType(MediaType.APPLICATION_JSON),
+                status().isOk());
+        UUID compositeInGroupUuid = networkModificationRepository.getModifications(TEST_GROUP_ID, true, true).getLast().getUuid();
+
+        mvcResult = mockMvc.perform(post(URI_COMPOSITE_NETWORK_MODIF_BASE + "/" + compositeInGroupUuid + "/share")
+                        .queryParam("groupUuid", TEST_GROUP_ID.toString())
+                        .queryParam("name", "shared composite"))
+                .andExpect(status().isOk())
+                .andReturn();
+        UUID sharedCompositeUuid = mapper.readValue(mvcResult.getResponse().getContentAsString(), new TypeReference<>() { });
+
+        // the composite modification is shared as it was, keeping its own uuid
+        assertEquals(compositeInGroupUuid, sharedCompositeUuid);
+
+        // and a reference to it took its place in the group
+        List<ModificationInfos> newModificationList = networkModificationRepository.getModifications(TEST_GROUP_ID, false, true);
+        assertEquals(modificationsNumber + 1, newModificationList.size());
+
+        ModificationReferenceInfos reference = assertInstanceOf(ModificationReferenceInfos.class, newModificationList.getLast());
+        assertEquals(sharedCompositeUuid, reference.getReferenceId());
+        assertEquals(ModificationReferenceInfos.Type.BASIC, reference.getReferenceType());
+
+        CompositeModificationInfos sharedComposite = assertInstanceOf(CompositeModificationInfos.class, reference.getReferenceInfos());
+        assertEquals(sharedCompositeUuid, sharedComposite.getUuid());
+        assertEquals("shared composite", sharedComposite.getName());
+        checkCompositeModificationContent(sharedComposite.getModificationsInfos());
+
+        // sharing a modification which is not a composite one is rejected
+        mockMvc.perform(post(URI_COMPOSITE_NETWORK_MODIF_BASE + "/" + modificationList.getFirst().getUuid() + "/share")
+                        .queryParam("groupUuid", TEST_GROUP_ID.toString())
+                        .queryParam("name", "not a composite"))
+                .andExpect(status().isBadRequest());
+    }
+
     private static void checkCompositeModificationContent(List<ModificationInfos> compositeModificationContent) {
         assertEquals("open", ((EquipmentAttributeModificationInfos) compositeModificationContent.getFirst()).getEquipmentAttributeName());
         assertEquals(Boolean.TRUE, ((EquipmentAttributeModificationInfos) compositeModificationContent.getFirst()).getEquipmentAttributeValue());

--- a/src/test/java/org/gridsuite/modification/server/CompositeControllerTest.java
+++ b/src/test/java/org/gridsuite/modification/server/CompositeControllerTest.java
@@ -297,26 +297,22 @@ class CompositeControllerTest {
                 status().isOk());
         UUID compositeInGroupUuid = networkModificationRepository.getModifications(TEST_GROUP_ID, true, true).getLast().getUuid();
 
-        mvcResult = mockMvc.perform(post(URI_COMPOSITE_NETWORK_MODIF_BASE + "/" + compositeInGroupUuid + "/share")
+        mockMvc.perform(post(URI_COMPOSITE_NETWORK_MODIF_BASE + "/" + compositeInGroupUuid + "/share")
                         .queryParam("groupUuid", TEST_GROUP_ID.toString())
                         .queryParam("name", "shared composite"))
-                .andExpect(status().isOk())
-                .andReturn();
-        UUID sharedCompositeUuid = mapper.readValue(mvcResult.getResponse().getContentAsString(), new TypeReference<>() { });
+                .andExpect(status().isOk());
 
-        // the composite modification is shared as it was, keeping its own uuid
-        assertEquals(compositeInGroupUuid, sharedCompositeUuid);
-
-        // and a reference to it took its place in the group
+        // the composite modification is shared as it was, keeping its own uuid, and a reference to it took its place
+        // in the group
         List<ModificationInfos> newModificationList = networkModificationRepository.getModifications(TEST_GROUP_ID, false, true);
         assertEquals(modificationsNumber + 1, newModificationList.size());
 
         ModificationReferenceInfos reference = assertInstanceOf(ModificationReferenceInfos.class, newModificationList.getLast());
-        assertEquals(sharedCompositeUuid, reference.getReferenceId());
+        assertEquals(compositeInGroupUuid, reference.getReferenceId());
         assertEquals(ModificationReferenceInfos.Type.BASIC, reference.getReferenceType());
 
         CompositeModificationInfos sharedComposite = assertInstanceOf(CompositeModificationInfos.class, reference.getReferenceInfos());
-        assertEquals(sharedCompositeUuid, sharedComposite.getUuid());
+        assertEquals(compositeInGroupUuid, sharedComposite.getUuid());
         assertEquals("shared composite", sharedComposite.getName());
         checkCompositeModificationContent(sharedComposite.getModificationsInfos());
 


### PR DESCRIPTION
Adds `POST /v1/network-composite-modifications/{uuid}/share?groupUuid=&name=`, used when a composite modification of a study node becomes a shared modification stored in GridExplore.

In a single transaction, the composite modification is taken out of its group and a `MODIFICATION_REFERENCE` to it takes its place, at the very same order. The composite keeps its own uuid — it is moved, not duplicated — so the caller can store it in the directory server under that uuid, and it is renamed when a name is given.

Sharing a modification which is not a composite one is rejected with the new `MODIFICATION_BAD_TYPE` business error, and sharing one which is not owned by the given group with `MODIFICATION_NOT_FOUND`.